### PR TITLE
fix: Error fix update state during render

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,29 +15,38 @@ import GlobalStyles from './components/GlobalStyles.tsx';
 import { DragOverlay } from '@dnd-kit/core';
 import { PiecesInPlayContext } from './context/PiecesInPlay.tsx';
 import { CurrentLevelContext } from './context/CurrentLevel.tsx';
+import { useInitialPieces } from './hooks/useInitialPieces';
 
 import { Piece } from './types/piece.ts';
 
 function App() {
-  const { currentLevel, levelPosition, previousLevel, nextLevel, setSizeOfEachUnit } =
-    useContext(CurrentLevelContext);
+  const {
+    currentLevel,
+    levelPosition,
+    previousLevel,
+    nextLevel,
+    setSizeOfEachUnit,
+  } = useContext(CurrentLevelContext);
   const [activePiece, setActivePiece] = useState<Piece | null>(null);
   const { piecesInPlay, resetPieces, setPiecesForNewLevel } =
     useContext(PiecesInPlayContext);
   const [isRotating, setIsRotating] = useState(false);
+  const getInitialPieces = useInitialPieces;
 
   const boardRef = useRef(null);
 
   async function setToPrevious() {
     await previousLevel();
-    await setSizeOfEachUnit(currentLevel);
-    await setPiecesForNewLevel();
+    const newPieces = getInitialPieces(currentLevel - 1);
+    await setPiecesForNewLevel(newPieces);
+    await setSizeOfEachUnit(currentLevel - 1);
   }
 
   async function setToNext() {
     await nextLevel();
-    await setSizeOfEachUnit(currentLevel);
-    await setPiecesForNewLevel();
+    const newPieces = getInitialPieces(currentLevel + 1);
+    await setPiecesForNewLevel(newPieces);
+    await setSizeOfEachUnit(currentLevel + 1);
   }
 
   return (
@@ -49,11 +58,17 @@ function App() {
         isRotating={isRotating}
         setIsRotating={setIsRotating}
       >
-        
         <PiecesContainer $currentLevel={currentLevel}>
           {piecesInPlay.map((piece: Piece, pieceIndex: number) => {
             if (piece.location != null) return null;
-            return <InitialPuzzlePiece piece={piece} isRotating={isRotating} setIsRotating={setIsRotating} key={pieceIndex} />;
+            return (
+              <InitialPuzzlePiece
+                piece={piece}
+                isRotating={isRotating}
+                setIsRotating={setIsRotating}
+                key={pieceIndex}
+              />
+            );
           })}
         </PiecesContainer>
         <BoardWrapper>
@@ -62,7 +77,11 @@ function App() {
             dimensions={levels[currentLevel].dimensions}
             boardSections={levels[currentLevel].boardSections}
           />
-          <PlacedPieces piecesInPlay={piecesInPlay} isRotating={isRotating} setIsRotating={setIsRotating} />
+          <PlacedPieces
+            piecesInPlay={piecesInPlay}
+            isRotating={isRotating}
+            setIsRotating={setIsRotating}
+          />
         </BoardWrapper>
         {activePiece && !isRotating ? (
           <DragOverlay>
@@ -78,10 +97,13 @@ function App() {
           Next Level
         </Button>
         <Button onClick={resetPieces}>Reset Game</Button>
-        <InstructionsModal isRotating={isRotating} setIsRotating={setIsRotating} piecesInPlay={piecesInPlay} />
+        <InstructionsModal
+          isRotating={isRotating}
+          setIsRotating={setIsRotating}
+          piecesInPlay={piecesInPlay}
+        />
       </ButtonContainer>
       <GlobalStyles />
-      
     </Main>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ import { CurrentLevelContext } from './context/CurrentLevel.tsx';
 import { Piece } from './types/piece.ts';
 
 function App() {
-  const { currentLevel, levelPosition, previousLevel, nextLevel } =
+  const { currentLevel, levelPosition, previousLevel, nextLevel, setSizeOfEachUnit } =
     useContext(CurrentLevelContext);
   const [activePiece, setActivePiece] = useState<Piece | null>(null);
   const { piecesInPlay, resetPieces, setPiecesForNewLevel } =
@@ -27,7 +27,19 @@ function App() {
   const [isRotating, setIsRotating] = useState(false);
 
   const boardRef = useRef(null);
-  setPiecesForNewLevel();
+
+  async function setToPrevious() {
+    await previousLevel();
+    await setSizeOfEachUnit(currentLevel);
+    await setPiecesForNewLevel();
+  }
+
+  async function setToNext() {
+    await nextLevel();
+    await setSizeOfEachUnit(currentLevel);
+    await setPiecesForNewLevel();
+  }
+
   return (
     <Main>
       <DragAndDropArea
@@ -59,10 +71,10 @@ function App() {
         ) : null}
       </DragAndDropArea>
       <ButtonContainer>
-        <Button disabled={levelPosition == 'first'} onClick={previousLevel}>
+        <Button disabled={levelPosition == 'first'} onClick={setToPrevious}>
           Previous Level
         </Button>
-        <Button disabled={levelPosition == 'last'} onClick={nextLevel}>
+        <Button disabled={levelPosition == 'last'} onClick={setToNext}>
           Next Level
         </Button>
         <Button onClick={resetPieces}>Reset Game</Button>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,20 +31,19 @@ function App() {
   const { piecesInPlay, resetPieces, setPiecesForNewLevel } =
     useContext(PiecesInPlayContext);
   const [isRotating, setIsRotating] = useState(false);
-  const getInitialPieces = useInitialPieces;
 
   const boardRef = useRef(null);
 
   async function setToPrevious() {
     await previousLevel();
-    const newPieces = getInitialPieces(currentLevel - 1);
+    const newPieces = useInitialPieces(currentLevel - 1);
     await setPiecesForNewLevel(newPieces);
     await setSizeOfEachUnit(currentLevel - 1);
   }
 
   async function setToNext() {
     await nextLevel();
-    const newPieces = getInitialPieces(currentLevel + 1);
+    const newPieces = useInitialPieces(currentLevel + 1);
     await setPiecesForNewLevel(newPieces);
     await setSizeOfEachUnit(currentLevel + 1);
   }

--- a/src/context/CurrentLevel.tsx
+++ b/src/context/CurrentLevel.tsx
@@ -71,8 +71,17 @@ function CurrentLevelProvider({ children }: CurrentLevelProviderProps) {
       isRotated: false,
     }))
   ];
-  console.log(initialPieces);
   
+  function setSizeOfEachUnit(currentLevel: number) {
+    const { width, height } = levels[currentLevel].dimensions;
+    const sizeOfEachUnit = Math.round(
+      (0.55 * Math.min(windowWidth, windowHeight)) / Math.max(width, height)
+    );
+    document.documentElement.style.setProperty(
+      '--sizeOfEachUnit',
+      `${sizeOfEachUnit}px`
+    );
+  }
 
   function nextLevel() {
     if (currentLevel === numberOfLevels - 1) {
@@ -99,6 +108,7 @@ function CurrentLevelProvider({ children }: CurrentLevelProviderProps) {
           levelPosition,
           boardDimensions,
           sizeOfEachUnit,
+          setSizeOfEachUnit,
           nextLevel,
           previousLevel,
           setCurrentLevel,

--- a/src/context/CurrentLevel.tsx
+++ b/src/context/CurrentLevel.tsx
@@ -24,6 +24,26 @@ interface CurrentLevelProviderProps {
   children: ReactNode;
 }
 
+function useInitialPieces(level: number) {
+  return [
+    {
+      width: 3,
+      height: 2,
+      location: 'instructions',
+      color: 'hsl(0, 61%, 66%)',
+      id: 'sample-0',
+      isRotated: false,
+    },
+    ...levels[level].pieces.map((piece, index) => ({
+      ...piece,
+      location: initialLocation,
+      color: colors[index % colors.length],
+      id: `initial-${index + 1}`,
+      isRotated: false,
+    })),
+  ];
+}
+
 function CurrentLevelProvider({ children }: CurrentLevelProviderProps) {
   const [currentLevel, setCurrentLevel] = useState(0);
 
@@ -54,24 +74,8 @@ function CurrentLevelProvider({ children }: CurrentLevelProviderProps) {
     levelPosition = 'middle';
   }
 
-  const initialPieces = [
-    {
-      width: 3,
-      height: 2,
-      location: 'instructions',
-      color: 'hsl(0, 61%, 66%)',
-      id: 'sample-0',
-      isRotated: false,
-    },
-    ...levels[currentLevel].pieces.map((piece, index) => ({
-      ...piece,
-      location: initialLocation,
-      color: colors[index % colors.length],
-      id: `initial-${index+1}`,
-      isRotated: false,
-    }))
-  ];
-  
+  const initialPieces = useInitialPieces(currentLevel);
+
   function setSizeOfEachUnit(currentLevel: number) {
     const { width, height } = levels[currentLevel].dimensions;
     const sizeOfEachUnit = Math.round(
@@ -84,19 +88,23 @@ function CurrentLevelProvider({ children }: CurrentLevelProviderProps) {
   }
 
   function nextLevel() {
+    console.log('currentLevel before update', currentLevel);
     if (currentLevel === numberOfLevels - 1) {
       return;
     } else {
       setCurrentLevel(currentLevel + 1);
     }
+    console.log('currentLevel', currentLevel);
   }
 
   function previousLevel() {
+    console.log('currentLevel before update', currentLevel);
     if (currentLevel === 0) {
       return;
     } else {
       setCurrentLevel(currentLevel - 1);
     }
+    console.log('currentLevel', currentLevel);
   }
 
   return (

--- a/src/context/PiecesInPlay.tsx
+++ b/src/context/PiecesInPlay.tsx
@@ -17,7 +17,7 @@ export type PiecesInPlayContextType = {
   updateDimensions: (pieceIndex: number, width: number, height: number) => void;
   rotatePiece: (pieceIndex: number) => void;
   resetPieces: () => void;
-  setPiecesForNewLevel: () => void;
+  setPiecesForNewLevel: (newPieces?: InitialPiece[]) => void;
 };
 
 export const PiecesInPlayContext =
@@ -60,7 +60,9 @@ function PiecesInPlayProvider({ children }: { children: React.ReactNode }) {
     updatedPieces[pieceIndex].width = width;
     updatedPieces[pieceIndex].height = height;
     setPiecesInPlay(updatedPieces);
-    console.log(`Reset piece ${pieceIndex} to have width:${width} and height:${height}`)
+    console.log(
+      `Reset piece ${pieceIndex} to have width:${width} and height:${height}`
+    );
   }
 
   // function resetPieces() {
@@ -93,14 +95,13 @@ function PiecesInPlayProvider({ children }: { children: React.ReactNode }) {
           color: colors[index % colors.length],
           id: `initial-${index + 1}`,
           isRotated: false,
-        }))
+        })),
       ];
       setPiecesInPlay(piecesAfterReset);
     } catch (error) {
       console.error('Error resetting pieces:', error);
     }
   }
-   
 
   function rotatePiece(pieceIndex: number) {
     const updatedPieces = [...piecesInPlay];
@@ -109,8 +110,8 @@ function PiecesInPlayProvider({ children }: { children: React.ReactNode }) {
     setPiecesInPlay(updatedPieces);
   }
 
-  function setPiecesForNewLevel() {
-    setPiecesInPlay(initialPieces);
+  function setPiecesForNewLevel(newPieces?: InitialPiece[]) {
+    setPiecesInPlay(newPieces || initialPieces);
   }
   return (
     <PiecesInPlayContext.Provider

--- a/src/context/PiecesInPlay.tsx
+++ b/src/context/PiecesInPlay.tsx
@@ -5,10 +5,11 @@ import {
   CurrentLevelContext,
   CurrentLevelContextType,
 } from './CurrentLevel.tsx';
-// import { colors } from '../CONSTANTS';
+import { colors } from '../CONSTANTS';
 import { InitialPiece, Piece } from '../types/piece.ts';
 import { convertLocationToXAndY } from '../utilities.ts';
 import { useAnimate } from 'motion/dist/react';
+import levels from '../levels.json';
 
 export type PiecesInPlayContextType = {
   piecesInPlay: Piece[];
@@ -24,7 +25,7 @@ export const PiecesInPlayContext =
 const initialLocation = null;
 
 function PiecesInPlayProvider({ children }: { children: React.ReactNode }) {
-  const { initialPieces, boardDimensions } =
+  const { initialPieces, boardDimensions, currentLevel } =
     useContext<CurrentLevelContextType>(CurrentLevelContext);
   const [piecesInPlay, setPiecesInPlay] = useState<InitialPiece[] | Piece[]>(
     initialPieces
@@ -62,17 +63,44 @@ function PiecesInPlayProvider({ children }: { children: React.ReactNode }) {
     console.log(`Reset piece ${pieceIndex} to have width:${width} and height:${height}`)
   }
 
+  // function resetPieces() {
+  //   const updatedPieces = [...piecesInPlay];
+  //   updatedPieces.forEach((piece, index) => {
+  //     piece.location = initialLocation;
+  //     piece.width = initialPieces[index].width;
+  //     piece.height = initialPieces[index].height;
+  //     piece.id = `initial-${index}`;
+  //     piece.isRotated = false;
+  //   });
+  //   setPiecesInPlay(updatedPieces);
+  // }
+
   function resetPieces() {
-    const updatedPieces = [...piecesInPlay];
-    updatedPieces.forEach((piece, index) => {
-      piece.location = initialLocation;
-      piece.width = initialPieces[index].width;
-      piece.height = initialPieces[index].height;
-      piece.id = `initial-${index}`;
-      piece.isRotated = false;
-    });
-    setPiecesInPlay(updatedPieces);
+    const initialLocation = null;
+    try {
+      const piecesAfterReset = [
+        {
+          width: 3,
+          height: 2,
+          location: 'instructions',
+          color: 'hsl(0, 61%, 66%)',
+          id: 'sample-0',
+          isRotated: false,
+        },
+        ...levels[currentLevel].pieces.map((piece, index) => ({
+          ...piece,
+          location: initialLocation,
+          color: colors[index % colors.length],
+          id: `initial-${index + 1}`,
+          isRotated: false,
+        }))
+      ];
+      setPiecesInPlay(piecesAfterReset);
+    } catch (error) {
+      console.error('Error resetting pieces:', error);
+    }
   }
+   
 
   function rotatePiece(pieceIndex: number) {
     const updatedPieces = [...piecesInPlay];

--- a/src/context/SelectedPiece.tsx
+++ b/src/context/SelectedPiece.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState } from 'react';
+import { createContext, useContext, useState, ReactNode } from 'react';
 import { Piece } from '../types/piece';
 
 export type SelectedPieceContextType = {
@@ -12,7 +12,7 @@ export type SelectedPieceContextType = {
 export const SelectedPieceContext =
   createContext<SelectedPieceContextType | null>(null);
 
-function SelectedPieceProvider({ children }: { children: React.ReactNode }) {
+function SelectedPieceProvider({ children }: { children: ReactNode }) {
   const [selectedPiece, setSelectedPiece] = useState<Piece | null>(null);
 
   return (

--- a/src/hooks/useInitialPieces.ts
+++ b/src/hooks/useInitialPieces.ts
@@ -1,0 +1,25 @@
+import { InitialPiece } from '../types/piece';
+import levels from '../levels.json';
+import { colors } from '../CONSTANTS';
+
+const initialLocation = null;
+
+export function useInitialPieces(level: number): InitialPiece[] {
+  return [
+    {
+      width: 3,
+      height: 2,
+      location: 'instructions',
+      color: 'hsl(0, 61%, 66%)',
+      id: 'sample-0',
+      isRotated: false,
+    },
+    ...levels[level].pieces.map((piece, index) => ({
+      ...piece,
+      location: initialLocation,
+      color: colors[index % colors.length],
+      id: `initial-${index + 1}`,
+      isRotated: false,
+    })),
+  ];
+}

--- a/src/types/piece.ts
+++ b/src/types/piece.ts
@@ -10,4 +10,8 @@ export interface Piece {
 export interface InitialPiece {
   width: number;
   height: number;
+  id: string;
+  location: string | null;
+  isRotated: boolean;
+  color: string;
 }


### PR DESCRIPTION
I am planning to implement pieces breaking into two and two pieces combining into one soon. This means the pieces will not always maintain a consistent index in the piecesInPlay array throughout a game. If a player breaks a piece at index 3 into two pieces, I will hold the information for those pieces at indexes 3 and 4 and shift the other pieces down.
To prepare the system for this new feature, I am having to refactor functions where pieces are assumed to have a constant index in the piecesInPlay array throughout the game because that won't be the case soon. 
In this PR I
- Refactored resetPieces() to derive the piece information directly from levels.json instead of iterating through the array and reseting each piece individually.
- Fixed bug that has been there for months but just recently started causing issues with the refactor (see image) 
![image](https://github.com/user-attachments/assets/b55d9e3b-38ae-4109-ac07-270cdff05c7a)
- Created a custom hook useInitialPieces to fix a RACE condition issue.
   _(Basically initialPieces was being derived from the currentLevel whenever the CurrentLevelProvider re-rendered BUT I needed to use initialPieces in the setToPrevious and setToNext functions in App.tsx before the provider was re-rendering.)_ 