### PR TITLE
Fix: Closes #29 Make example piece smaller

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,6 @@ import { DragOverlay } from '@dnd-kit/core';
 import { PiecesInPlayContext } from './context/PiecesInPlay.tsx';
 import { CurrentLevelContext } from './context/CurrentLevel.tsx';
 import { useInitialPieces } from './hooks/useInitialPieces';
-
 import { Piece } from './types/piece.ts';
 
 function App() {

--- a/src/components/ActionsToolbarPopover.tsx
+++ b/src/components/ActionsToolbarPopover.tsx
@@ -54,7 +54,7 @@ const ActionsToolbar = styled.div`
 
 function ActionsToolbarPopover({
   children,
-  runRotationAnimation,
+  runRotationAnimation, // lives in InitialPuzzlePiece
   ...delegated
 }: {
   children: React.ReactElement;
@@ -63,17 +63,12 @@ function ActionsToolbarPopover({
 }) {
   const context = useContext(PiecesInPlayContext);
   if (!context) {
-    throw new Error('ActionsToolbarPopover must be used within a PiecesInPlayProvider');
+    throw new Error(
+      'ActionsToolbarPopover must be used within a PiecesInPlayProvider'
+    );
   }
   const { updateDimensions } = context;
   const { selectedPiece } = useSelectedPiece();
-
-  function handleRotation() {
-    // const id = selectedPiece?.id;
-    // const pieceIndex = parseInt(id?.slice(id?.indexOf('-') + 1) ?? '0', 10);
-    // rotatePiece(pieceIndex);
-    runRotationAnimation(selectedPiece);
-  }
 
   function handleHorizontalStretch() {
     if (selectedPiece && Number.isInteger(selectedPiece.height / 2)) {
@@ -101,7 +96,7 @@ function ActionsToolbarPopover({
       <PopoverSurface id="actions">
         <ActionsToolbar>
           <Tooltip placement="bottom" title="Rotate">
-            <IconButton onClick={handleRotation}>
+            <IconButton onClick={() => runRotationAnimation(selectedPiece)}>
               <StyledRotateIcon />
             </IconButton>
           </Tooltip>

--- a/src/components/InitialPuzzlePiece.tsx
+++ b/src/components/InitialPuzzlePiece.tsx
@@ -10,7 +10,17 @@ import { Piece } from '../types/piece.ts';
 import styled from 'styled-components';
 import { mergeRefs } from '@chakra-ui/react';
 
-const InitialPuzzlePiece = ({ piece, isRotating, setIsRotating }: { piece: Piece, isRotating: boolean, setIsRotating: (isRotating: boolean) => void }) => {
+const InitialPuzzlePiece = ({
+  piece,
+  isRotating,
+  setIsRotating,
+  isExample = false,
+}: {
+  piece: Piece;
+  isRotating: boolean;
+  setIsRotating: (isRotating: boolean) => void;
+  isExample?: boolean;
+}) => {
   const { selectedPiece, setSelectedPiece } = useSelectedPiece();
   const [scope, animate] = useAnimate();
   const { updateDimensions } = useContext(PiecesInPlayContext);
@@ -32,8 +42,8 @@ const InitialPuzzlePiece = ({ piece, isRotating, setIsRotating }: { piece: Piece
       { rotate: 90 },
       { type: 'spring', stiffness: 150, damping: 11 }
     );
-      updateDimensions(pieceIndex, selectedPiece?.height, selectedPiece.width);
-      await animate(scope.current, { rotate: 0 }, { duration: 0 });
+    updateDimensions(pieceIndex, selectedPiece?.height, selectedPiece.width);
+    await animate(scope.current, { rotate: 0 }, { duration: 0 });
     setIsRotating(false);
   }
 
@@ -53,9 +63,10 @@ const InitialPuzzlePiece = ({ piece, isRotating, setIsRotating }: { piece: Piece
             width={piece.width}
             height={piece.height}
             color={piece.color}
-            isMotion={!isRotating}
+            isMotion={true}
             layout={!isRotating}
             isSelected={isSelected}
+            isExample={isExample}
           />
         </motion.button>
       </ActionsToolbarPopover>

--- a/src/components/InstructionsModal.tsx
+++ b/src/components/InstructionsModal.tsx
@@ -7,8 +7,8 @@ import {
   DialogTitle,
   DialogBody,
   DialogContent,
-  makeStyles
-} from "@fluentui/react-components";
+  makeStyles,
+} from '@fluentui/react-components';
 import styled from 'styled-components';
 import Button from './Button.tsx';
 import InitialPuzzlePiece from './InitialPuzzlePiece.tsx';
@@ -30,36 +30,45 @@ const useClasses = makeStyles({
     fontWeight: 600,
 
     '@media screen and (max-width: 768px)': {
-      width: '90%'
-    }
+      width: '90%',
+    },
   },
   Title: {
-    fontSize: '1.7rem'
+    fontSize: '1.7rem',
   },
   h2: {
     fontSize: '1.4rem',
-    marginTop: '15px'
+    marginTop: '15px',
   },
   div: {
     padding: '30px',
-    width: '90px'
- }
-})
+    width: '90px',
+  },
+});
 
-const InstructionsModal = ({ isRotating, setIsRotating, piecesInPlay }: { isRotating: boolean, setIsRotating: (isRotating: boolean) => void }) => {
+const InstructionsModal = ({
+  isRotating,
+  setIsRotating,
+  piecesInPlay,
+}: {
+  isRotating: boolean;
+  setIsRotating: (isRotating: boolean) => void;
+}) => {
   const classes = useClasses();
   const [instructionsShown, setInstructionsShown] = useState(false);
-    const context = useContext(PiecesInPlayContext);
+  const context = useContext(PiecesInPlayContext);
   if (!context) {
-    throw new Error('InstructionsModal must be used within a PiecesInPlayProvider');
+    throw new Error(
+      'InstructionsModal must be used within a PiecesInPlayProvider'
+    );
   }
   const { updateDimensions } = context;
 
   const closeModal = () => {
     updateDimensions(0, 3, 2);
     setInstructionsShown(false);
-  }
-  
+  };
+
   return (
     <Dialog modalType="non-modal" onOpenChange={closeModal}>
       <DialogTrigger disableButtonEnhancement>
@@ -72,13 +81,13 @@ const InstructionsModal = ({ isRotating, setIsRotating, piecesInPlay }: { isRota
             <div>
               <h2 className={classes.h2}>The Goal</h2>
               <p>Fill the board with pieces so that it's completely covered.</p>
-              
-              <h2 className={classes.h2} >The Rules</h2>
+
+              <h2 className={classes.h2}>The Rules</h2>
               <ul>
                 <li>Puzzle pieces cannot overlap.</li>
                 <li>Puzzle pieces must be fully on the board.</li>
               </ul>
-              
+
               <h2 className={classes.h2}>The Tools</h2>
               <ul>
                 <li>Rotate</li>
@@ -88,10 +97,13 @@ const InstructionsModal = ({ isRotating, setIsRotating, piecesInPlay }: { isRota
                 <li>Merge two pieces into one (coming soon!)</li>
               </ul>
               <h2 className={classes.h2}>Try clicking the piece below. </h2>
-                <div className={classes.div}>
-                <InitialPuzzlePiece piece={piecesInPlay[0]}
-                isRotating={isRotating}
-                setIsRotating={setIsRotating} />  
+              <div className={classes.div}>
+                <InitialPuzzlePiece
+                  piece={piecesInPlay[0]}
+                  isRotating={isRotating}
+                  setIsRotating={setIsRotating}
+                  isExample={true}
+                />
               </div>
             </div>
           </DialogContent>

--- a/src/components/PieceOnBoard.tsx
+++ b/src/components/PieceOnBoard.tsx
@@ -38,7 +38,17 @@ export const PieceWrapper = styled(motion.button).attrs(props => ({
       : 'none'};
 `;
 
-function PieceOnBoard({ piece, id, isRotating, setIsRotating }: { piece: Piece; id: string, isRotating: boolean, setIsRotating: (isRotating: boolean) => void }) {
+function PieceOnBoard({
+  piece,
+  id,
+  isRotating,
+  setIsRotating,
+}: {
+  piece: Piece;
+  id: string;
+  isRotating: boolean;
+  setIsRotating: (isRotating: boolean) => void;
+}) {
   const { selectedPiece, setSelectedPiece } =
     useContext<SelectedPieceContextType>(SelectedPieceContext);
   const { piecesInPlay, updateDimensions } =

--- a/src/components/Rectangle.tsx
+++ b/src/components/Rectangle.tsx
@@ -13,6 +13,7 @@ interface RectangleProps {
   isSelected?: boolean;
   isMotion?: boolean;
   layout?: boolean;
+  isExample?: boolean;
   style?: React.CSSProperties;
 }
 
@@ -21,6 +22,7 @@ const Container = styled(motion.div)<{
   $width: number;
   color: string;
   isSelected?: boolean;
+  isExample?: boolean;
 }>`
   transform: translate3d(0px, 0px, 0px) !important;
   display: grid;
@@ -44,6 +46,7 @@ function Rectangle(
     isMotion,
     isSelected,
     layout,
+    isExample,
     ...delegated
   }: RectangleProps,
   ref: React.Ref<HTMLDivElement>
@@ -61,9 +64,14 @@ function Rectangle(
     >
       {range(total).map(unit =>
         isMotion ? (
-          <MotionUnit key={unit} color={color} layout={layout} />
+          <MotionUnit
+            key={unit}
+            color={color}
+            layout={layout}
+            isExample={isExample}
+          />
         ) : (
-          <Unit key={unit} />
+          <Unit key={unit} isExample={isExample} />
         )
       )}
     </Container>

--- a/src/components/Unit.tsx
+++ b/src/components/Unit.tsx
@@ -7,19 +7,20 @@ interface UnitProps extends ComponentProps<'div'> {
   ref?: any;
   id?: string;
   key?: number | string;
+  isExample?: boolean;
 }
 
-export const BasicUnit = styled.div<{ $color?: string }>`
-  width: var(--sizeOfEachUnit);
-  height: var(--sizeOfEachUnit);
+export const BasicUnit = styled.div<{ $color?: string; $isExample?: boolean }>`
+  width: ${props => (props.$isExample ? '30px' : 'var(--sizeOfEachUnit)')};
+  height: ${props => (props.$isExample ? '30px' : 'var(--sizeOfEachUnit)')};
   border: 1px solid black;
   border-radius: 0px;
   background-color: ${props => props.$color || 'transparent'};
 `;
 
 export const Unit = forwardRef<HTMLDivElement, UnitProps>(
-  ({ color, ...delegated }, ref) => {
-    return <BasicUnit {...delegated} ref={ref} />;
+  ({ color, isExample, ...delegated }, ref) => {
+    return <BasicUnit {...delegated} ref={ref} $isExample={isExample} />;
   }
 );
 
@@ -28,9 +29,17 @@ export const StyledMotionUnit = styled(BasicUnit).attrs({ as: motion.div })``;
 export const MotionUnit = ({
   color,
   layout = true,
+  isExample,
 }: {
   color?: string;
   layout?: boolean;
+  isExample?: boolean;
 }) => {
-  return <StyledMotionUnit layout={layout} $color={color || 'transparent'} />;
+  return (
+    <StyledMotionUnit
+      layout={layout}
+      $color={color || 'transparent'}
+      $isExample={isExample}
+    />
+  );
 };


### PR DESCRIPTION
I added a prop to initialPuzzlePiece and used prop drilling to propagate it all the way down to the unit component. In the unit component, I set the width and height to a constant 30px IF isExample is true, but otherwise it's set to the css variable sizeOfEachUnit. 

This caused some weird bugs where the piece would temporarily become much larger immediately after rotating due to changing to a regular div and then back to a motion.div. I realized that logic was no longer needed because my rotation logic works fine when it's a div the whole time. So I changed the isMotion prop to always be true within initialPuzzlePiece and pieceOnBoard. 