### PR TITLE
Julianna/55 fix excessive shifting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -138,7 +138,7 @@ export const PiecesContainer = styled(motion.div).attrs({
   flex-wrap: wrap;
   align-items: start;
   justify-content: right;
-  gap: calc(var(--sizeOfEachUnit) - 2px);
+  gap: var(--sizeOfEachUnit);
 `;
 // Not sure why subtracting 2 from the sizeOfEachUnit works here. May be a box-sizing issue although it should all be set to border-box...
 

--- a/src/components/DragAndDropArea.tsx
+++ b/src/components/DragAndDropArea.tsx
@@ -8,7 +8,11 @@ import {
   useSensors,
 } from '@dnd-kit/core';
 import type { DragStartEvent, DragEndEvent } from '@dnd-kit/core';
-import { createSnapModifier, restrictToWindowEdges } from '@dnd-kit/modifiers';
+import {
+  createSnapModifier,
+  restrictToWindowEdges,
+  snapCenterToCursor,
+} from '@dnd-kit/modifiers';
 import { CurrentLevelContext } from '../context/CurrentLevel.tsx';
 import { PiecesInPlayContext } from '../context/PiecesInPlay.tsx';
 import { Piece } from '../types/piece';
@@ -71,13 +75,14 @@ function DragAndDropArea({
     const pieceIndex = parseInt(id.slice(id.indexOf('-') + 1), 10);
     if (event?.over?.id) {
       const newLocation = event.over.id.toString();
+      console.log('newLocation', newLocation);
       movePiece(pieceIndex, newLocation);
     } else movePiece(pieceIndex, null);
   };
   return (
     <DndContext
       sensors={sensors}
-      modifiers={[snapToGrid]}
+      modifiers={[snapCenterToCursor, snapToGrid]}
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
     >

--- a/src/components/InitialPuzzlePiece.tsx
+++ b/src/components/InitialPuzzlePiece.tsx
@@ -56,7 +56,7 @@ const InitialPuzzlePiece = ({
         {...listeners}
         {...attributes}
         onClick={handlePieceSelected}
-        $isDragging={isDragging}
+        isDragging={isDragging}
       >
         <Rectangle
           width={piece.width}
@@ -72,7 +72,9 @@ const InitialPuzzlePiece = ({
   );
 };
 
-export const InitialPieceWrapper = styled.button`
+export const InitialPieceWrapper = styled.button.attrs(props => ({
+  $isDragging: props.isDragging,
+}))`
   visibility: ${({ isDragging }) => (isDragging ? 'hidden' : 'visible')};
   border: none;
   z-index: 2;

--- a/src/components/PieceOnBoard.tsx
+++ b/src/components/PieceOnBoard.tsx
@@ -24,6 +24,7 @@ import {
 export const PieceWrapper = styled.button.attrs(props => ({
   onClick: props.onClick,
   ref: props.ref,
+  $isDragging: props.isDragging,
   animate: props.animate,
   transition: props.transition,
 }))`
@@ -98,7 +99,7 @@ function PieceOnBoard({
         onClick={handlePieceSelected}
         x={x}
         y={y}
-        $isDragging={isDragging}
+        isDragging={isDragging}
       >
         <Rectangle
           width={piece.width}

--- a/src/context/PiecesInPlay.tsx
+++ b/src/context/PiecesInPlay.tsx
@@ -34,18 +34,36 @@ function PiecesInPlayProvider({ children }: { children: React.ReactNode }) {
 
   function movePiece(pieceIndex: number, newLocation: string | null) {
     const updatedPieces = [...piecesInPlay];
+    const oldLocation = updatedPieces[pieceIndex].location;
     let newValidLocation = newLocation;
     if (newValidLocation != null) {
+      console.log('newValidLocation is not null');
       const { x, y } = convertLocationToXAndY(newValidLocation);
+      let correctedX = x;
+      let correctedY = y;
       const pieceHeight = piecesInPlay[pieceIndex].height;
       const pieceWidth = piecesInPlay[pieceIndex].width;
+      if (oldLocation === null) {
+        console.log('oldLocation', oldLocation);
+        console.log('x', x);
+        console.log('pieceWidth', pieceWidth);
+        if (pieceWidth > 1) {
+          correctedX = x - 1; // Temporary fix for pieces shifting one to the right when dragged from initial container
+          console.log('CORRECTED X', correctedX);
+        }
+      }
+      if (correctedX + pieceWidth > boardWidth) {
+        correctedX = boardWidth - pieceWidth;
+        console.log('CORRECTED X', correctedX);
+      }
+      // I have no idea why adding 1 works here to correct pieces placed below the bottom of the board
       if (y + pieceHeight + 1 > boardHeight) {
-        newValidLocation = `(${x},${boardHeight - pieceHeight})`;
+        correctedY = boardHeight - pieceHeight;
+        console.log('CORRECTED Y', correctedY);
       }
-      if (x + pieceWidth > boardWidth) {
-        newValidLocation = `(${boardWidth - pieceWidth},${y})`;
-      }
+      newValidLocation = `(${correctedX},${correctedY})`;
     }
+    console.log('newValidLocation', newValidLocation);
     updatedPieces[pieceIndex].location = newValidLocation;
     if (newValidLocation != null) {
       updatedPieces[pieceIndex].id = `inPlay-${pieceIndex}`;


### PR DESCRIPTION
I added a temporary fix until I can better understand exactly why this is happening. 
The fix is whenever the pieceWidth is greater than 1, to subtract 1 from the x value (because for some reason it's shifting the larger pieces one to the right). 
I also cleaned up the logic that ensures each piece is placed in a valid location in the PiecesInPlay context. 