### PR TITLE
fix: Closes #24 Fix rotations that make pieces go off the board

### DIFF
--- a/src/components/PieceOnBoard.tsx
+++ b/src/components/PieceOnBoard.tsx
@@ -51,7 +51,7 @@ function PieceOnBoard({
 }) {
   const { selectedPiece, setSelectedPiece } =
     useContext<SelectedPieceContextType>(SelectedPieceContext);
-  const { piecesInPlay, updateDimensions } =
+  const { piecesInPlay, updateDimensions, movePiece } =
     useContext<PiecesInPlayContextType>(PiecesInPlayContext);
   const { sizeOfEachUnit } =
     useContext<CurrentLevelContextType>(CurrentLevelContext);
@@ -82,6 +82,12 @@ function PieceOnBoard({
       await animate(scope.current, { rotate: 0 }, { duration: 0 });
     } finally {
       setIsRotating(false);
+      const { x, y } = convertLocationToXAndY(selectedPiece.location);
+      let newX = x + Math.ceil(selectedPiece.height / 2) - 1;
+      let newY = y + Math.ceil(selectedPiece.width / 2) - 1;
+      console.log('newX', newX);
+      console.log('newY', newY);
+      movePiece(pieceIndex, `(${newX},${newY})`);
     }
   }
 

--- a/src/components/PieceOnBoard.tsx
+++ b/src/components/PieceOnBoard.tsx
@@ -85,8 +85,6 @@ function PieceOnBoard({
       const { x, y } = convertLocationToXAndY(selectedPiece.location);
       let newX = x + Math.ceil(selectedPiece.height / 2) - 1;
       let newY = y + Math.ceil(selectedPiece.width / 2) - 1;
-      console.log('newX', newX);
-      console.log('newY', newY);
       movePiece(pieceIndex, `(${newX},${newY})`);
     }
   }

--- a/src/context/PiecesInPlay.tsx
+++ b/src/context/PiecesInPlay.tsx
@@ -43,7 +43,7 @@ function PiecesInPlayProvider({ children }: { children: React.ReactNode }) {
       const pieceHeight = piecesInPlay[pieceIndex].height;
       const pieceWidth = piecesInPlay[pieceIndex].width;
       if (oldLocation === null) {
-        if (pieceWidth > 1) {
+        if (pieceWidth > 1 && x > 0) {
           correctedX = x - 1; // Temporary fix for pieces shifting one to the right when dragged from initial container
         }
       }


### PR DESCRIPTION
Closes #24 
I added the following logic to the runAnimation function in the pieceOnBoard component (because this would never be an issue when rotating initialPuzzlePiece components).
```
const { x, y } = convertLocationToXAndY(selectedPiece.location);
let newX = x + Math.ceil(selectedPiece.height / 2) - 1;
let newY = y + Math.ceil(selectedPiece.width / 2) - 1;
movePiece(pieceIndex, `(${newX},${newY})`);
```
I am subtracting 1 because the locations on the grid start at 0 and this logic would shift them over too much because of that. 