### PR TITLE
Closes #49 Change icons to SVGs to load faster

### DIFF
--- a/src/components/ActionsToolbarPopover.tsx
+++ b/src/components/ActionsToolbarPopover.tsx
@@ -9,6 +9,7 @@ import {
 import styled from 'styled-components';
 import { useSelectedPiece } from '../context/SelectedPiece.tsx';
 import { PiecesInPlayContext } from '../context/PiecesInPlay.tsx';
+import { HorizontalStretchIcon, VerticalStretchIcon } from './SvgIcons.tsx';
 
 const StyledRotateIcon = styled(RotateRightOutlined)`
   font-size: 32px;
@@ -23,13 +24,15 @@ const IconButton = styled.button`
   padding: 0px;
   margin: 0px;
   border: none;
-`;
 
-const Icon = styled.img`
-  width: 32px;
+  svg {
+    width: 32px;
+    height: 32px;
 
-  @media (max-width: 750px) {
-    width: 20px;
+    @media (max-width: 750px) {
+      width: 20px;
+      height: 20px;
+    }
   }
 `;
 
@@ -102,12 +105,12 @@ function ActionsToolbarPopover({
           </Tooltip>
           <Tooltip placement="bottom" title="Double Width & Halve Height">
             <IconButton onClick={handleHorizontalStretch}>
-              <Icon src="./assets/horizontalStretch.svg" />
+              <HorizontalStretchIcon />
             </IconButton>
           </Tooltip>
           <Tooltip placement="bottom" title="Halve Width & Double Height">
             <IconButton onClick={handleVerticalStretch}>
-              <Icon src="./assets/verticalStretch.svg" />
+              <VerticalStretchIcon />
             </IconButton>
           </Tooltip>
         </ActionsToolbar>

--- a/src/components/InitialPuzzlePiece.tsx
+++ b/src/components/InitialPuzzlePiece.tsx
@@ -72,9 +72,7 @@ const InitialPuzzlePiece = ({
   );
 };
 
-export const InitialPieceWrapper = styled.button.attrs(props => ({
-  $isDragging: props.isDragging,
-}))`
+export const InitialPieceWrapper = styled.button`
   visibility: ${({ isDragging }) => (isDragging ? 'hidden' : 'visible')};
   border: none;
   z-index: 2;

--- a/src/components/SvgIcons.tsx
+++ b/src/components/SvgIcons.tsx
@@ -1,0 +1,231 @@
+export const HorizontalStretchIcon = ({ size = '32px' }) => {
+  return (
+    <svg
+      id="e1m6fFAuxBZ1"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 300 300"
+      shapeRendering="geometricPrecision"
+      textRendering="geometricPrecision"
+      width={size}
+      height={size}
+    >
+      <g>
+        <line
+          x1="0"
+          y1="-84.938704"
+          x2="0"
+          y2="84.938704"
+          transform="translate(150 95.212943)"
+          fill="none"
+          stroke="#007571"
+          strokeWidth="20"
+        />
+        <line
+          x1="-20.869819"
+          y1="-21.599533"
+          x2="20.869819"
+          y2="21.599533"
+          transform="translate(135.130181 165.207239)"
+          fill="none"
+          stroke="#007571"
+          strokeWidth="20"
+        />
+        <line
+          x1="-20.869819"
+          y1="-21.599533"
+          x2="20.869819"
+          y2="21.599533"
+          transform="matrix(-1 0 0 1 163.869819 165.207239)"
+          fill="none"
+          stroke="#007571"
+          strokeWidth="20"
+        />
+      </g>
+      <g transform="matrix(.012771-.999918 1.082433 0.013825-14.778236 300.814093)">
+        <line
+          x1="-20.869819"
+          y1="-21.599533"
+          x2="20.869819"
+          y2="21.599533"
+          transform="matrix(-1 0 0 1 78.259807 228.6054)"
+          fill="none"
+          stroke="#007571"
+          strokeWidth="20"
+        />
+        <line
+          x1="-20.869819"
+          y1="-21.599533"
+          x2="20.869819"
+          y2="21.599533"
+          transform="matrix(-1 0 0 1 49.052546 79.199138)"
+          fill="none"
+          stroke="#007571"
+          strokeWidth="20"
+        />
+        <line
+          x1="-20.869819"
+          y1="-21.599533"
+          x2="20.869819"
+          y2="21.599533"
+          transform="translate(49.519431 228.499218)"
+          fill="none"
+          stroke="#007571"
+          strokeWidth="20"
+        />
+        <line
+          x1="0"
+          y1="-84.938704"
+          x2="0"
+          y2="84.938704"
+          transform="matrix(-1 0 0 1.048692 64.249097 155.046605)"
+          fill="none"
+          stroke="#007571"
+          strokeWidth="20"
+        />
+      </g>
+      <line
+        x1="-20.869819"
+        y1="-21.599533"
+        x2="20.869819"
+        y2="21.599533"
+        transform="matrix(-1 0 0 1 72.062536 222.11423)"
+        fill="none"
+        stroke="#007571"
+        strokeWidth="20"
+      />
+    </svg>
+  );
+};
+
+export const VerticalStretchIcon = ({ size = '32px' }) => {
+  return (
+    <svg
+      id="ey6e2aViMBP1"
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      viewBox="0 0 300 300"
+      shapeRendering="geometricPrecision"
+      textRendering="geometricPrecision"
+      width={size}
+      height={size}
+    >
+      <g transform="translate(0 16)">
+        <line
+          x1="0"
+          y1="-84.938704"
+          x2="0"
+          y2="84.938704"
+          transform="translate(150 95.212943)"
+          fill="none"
+          stroke="#007571"
+          strokeWidth="20"
+        />
+        <line
+          x1="-20.869819"
+          y1="-21.599533"
+          x2="20.869819"
+          y2="21.599533"
+          transform="translate(135.130181 165.207239)"
+          fill="none"
+          stroke="#007571"
+          strokeWidth="20"
+        />
+        <line
+          x1="-20.869819"
+          y1="-21.599533"
+          x2="20.869819"
+          y2="21.599533"
+          transform="matrix(-1 0 0 1 163.869819 165.207239)"
+          fill="none"
+          stroke="#007571"
+          strokeWidth="20"
+        />
+      </g>
+      <g transform="matrix(.012771-.999918 1.00112 0.012787-116.621061 300.985667)">
+        <line
+          x1="-20.869819"
+          y1="-21.599533"
+          x2="20.869819"
+          y2="21.599533"
+          transform="matrix(-1 0 0 1 78.259807 228.6054)"
+          fill="none"
+          stroke="#007571"
+          strokeWidth="20"
+        />
+        <line
+          x1="-20.869819"
+          y1="-21.599533"
+          x2="20.869819"
+          y2="21.599533"
+          transform="translate(49.519431 228.499218)"
+          fill="none"
+          stroke="#007571"
+          strokeWidth="20"
+        />
+        <line
+          x1="0"
+          y1="-84.938704"
+          x2="0"
+          y2="84.938704"
+          transform="matrix(-1 0 0 0.473299 63.127174 188.85687)"
+          fill="none"
+          stroke="#007571"
+          strokeWidth="20"
+        />
+      </g>
+      <g transform="matrix(.012771-.999918-1.00112-.012787 419.123803 307.531974)">
+        <line
+          x1="-20.869819"
+          y1="-21.599533"
+          x2="20.869819"
+          y2="21.599533"
+          transform="matrix(-1 0 0 1 78.259807 228.6054)"
+          fill="none"
+          stroke="#007571"
+          strokeWidth="20"
+        />
+        <line
+          x1="-20.869819"
+          y1="-21.599533"
+          x2="20.869819"
+          y2="21.599533"
+          transform="translate(49.519431 228.499218)"
+          fill="none"
+          stroke="#007571"
+          strokeWidth="20"
+        />
+        <line
+          x1="0"
+          y1="-84.938704"
+          x2="0"
+          y2="84.938704"
+          transform="matrix(-1 0 0 0.473299 63.127174 188.85687)"
+          fill="none"
+          stroke="#007571"
+          strokeWidth="20"
+        />
+      </g>
+      <line
+        x1="-20.869819"
+        y1="-21.599533"
+        x2="20.869819"
+        y2="21.599533"
+        transform="matrix(-1 0 0 1 133.130181 39.117648)"
+        fill="none"
+        stroke="#007571"
+        strokeWidth="20"
+      />
+      <line
+        x1="-20.869819"
+        y1="-21.599533"
+        x2="20.869819"
+        y2="21.599533"
+        transform="translate(162.869819 39.117648)"
+        fill="none"
+        stroke="#007571"
+        strokeWidth="20"
+      />
+    </svg>
+  );
+};


### PR DESCRIPTION
Closes #49
I changed the icons I created myself to use the svg tag directly instead of passing the svg links in through an img tag. Now the icons all load at the same speed. 