### PR TITLE
fix closes #61 by adding layoutId to the initialPuzzlePieces

### DIFF
--- a/src/components/ActionsToolbarPopover.tsx
+++ b/src/components/ActionsToolbarPopover.tsx
@@ -1,6 +1,7 @@
 import { useContext } from 'react';
 import { Tooltip } from 'antd';
 import { RotateRightOutlined } from '@ant-design/icons';
+import { motion } from 'motion/react';
 import {
   Popover,
   PopoverTrigger,
@@ -36,7 +37,7 @@ const IconButton = styled.button`
   }
 `;
 
-const ActionsToolbar = styled.div`
+const ActionsToolbar = styled(motion.div)`
   background-color: white;
   color: hsl(178, 100%, 23%);
   border-radius: 5px;

--- a/src/components/InitialPuzzlePiece.tsx
+++ b/src/components/InitialPuzzlePiece.tsx
@@ -57,6 +57,7 @@ const InitialPuzzlePiece = ({
         {...attributes}
         onClick={handlePieceSelected}
         isDragging={isDragging}
+        layoutId={piece.id}
       >
         <Rectangle
           width={piece.width}
@@ -72,7 +73,7 @@ const InitialPuzzlePiece = ({
   );
 };
 
-export const InitialPieceWrapper = styled.button`
+export const InitialPieceWrapper = styled(motion.button)`
   visibility: ${({ isDragging }) => (isDragging ? 'hidden' : 'visible')};
   border: none;
   z-index: 2;

--- a/src/components/InstructionsModal.tsx
+++ b/src/components/InstructionsModal.tsx
@@ -19,7 +19,8 @@ import { PiecesInPlayContext } from '../context/PiecesInPlay.tsx';
 // Instructions on how to use Griffel/ makeStyles here: https://learn.microsoft.com/en-us/shows/fluent-ui-insights/fluent-ui-trainings-styling-components-theming#time=20m55s
 const useClasses = makeStyles({
   Surface: {
-    backgroundColor: '#007571',
+    backgroundColor: 'hsl(100, 40%, 86%)',
+    color: 'black',
     width: '70%',
     paddingBottom: '3px',
     paddingInline: '20px',
@@ -63,7 +64,7 @@ const useClasses = makeStyles({
     position: 'absolute',
     top: '15px',
     right: '15px',
-    color: 'white',
+    color: 'black',
     cursor: 'pointer',
   },
   li: {


### PR DESCRIPTION
I added a layoutId to each puzzle piece in the initialPieceWrapper container in App.tsx. This tells framer motion that each piece is still the same piece even when one is removed from the set, the others will still have their same layoutId as before and will be able to animate gracefully into place. 