### PR TITLE
fix: stretching after rotation animation fixed 

### DIFF
--- a/src/components/DragAndDropArea.tsx
+++ b/src/components/DragAndDropArea.tsx
@@ -6,17 +6,11 @@ import {
   TouchSensor,
   KeyboardSensor,
   useSensors,
-  closestCenter,
-  closestCorners,
   rectIntersection,
 } from '@dnd-kit/core';
 import type { DragStartEvent, DragEndEvent } from '@dnd-kit/core';
-import {
-  createSnapModifier,
-  // restrictToWindowEdges,
-  // snapCenterToCursor,
-} from '@dnd-kit/modifiers';
-import { CurrentLevelContext } from '../context/CurrentLevel';
+// import { createSnapModifier } from '@dnd-kit/modifiers';
+// import { CurrentLevelContext } from '../context/CurrentLevel';
 import { PiecesInPlayContext } from '../context/PiecesInPlay';
 import { Piece } from '../types/piece';
 import { useSelectedPiece } from '../context/SelectedPiece';
@@ -37,7 +31,7 @@ function DragAndDropArea({
   setIsRotating,
 }: DragAndDropAreaProps) {
   const { setSelectedPiece } = useSelectedPiece();
-  const { sizeOfEachUnit } = useContext(CurrentLevelContext);
+  // const { sizeOfEachUnit } = useContext(CurrentLevelContext);
   const context = useContext(PiecesInPlayContext);
   if (!context) {
     throw new Error(
@@ -55,34 +49,25 @@ function DragAndDropArea({
   }
 
   function customCollisionDetection(args: any) {
-    const { collisionRect, droppableRects, droppableContainers } = args;
-    // console.log('Collision detection args:', args);
-    // console.log({ collisionRect });
-    // console.log({ droppableRects });
-    // console.log({ droppableContainers });
-    // console.log('left:', args[0]);
+    const { collisionRect } = args;
 
     const x = collisionRect.left;
     const y = collisionRect.top;
 
-    //console.log('rectIntersection', rectIntersection(args));
-    // Still need to return actual collision results
-    // So just use the default rectangle intersection
     let potentialDroppables: any = rectIntersection(args);
     if (potentialDroppables[0]) {
       potentialDroppables.forEach((droppable: any) => {
         const droppableRect = droppable.data.droppableContainer.rect.current;
         droppable.data.value = rateDroppability(x, y, droppableRect);
       });
-      //console.log('Look at this:', potentialDroppables[0].data);
     }
     return potentialDroppables.sort(compareCollisionRects);
   }
 
-  const snapToGrid = useMemo(
-    () => createSnapModifier(sizeOfEachUnit),
-    [sizeOfEachUnit]
-  );
+  // const snapToGrid = useMemo(
+  //   () => createSnapModifier(sizeOfEachUnit),
+  //   [sizeOfEachUnit]
+  // );
   // const snapToGrid = createSnapModifier(sizeOfEachUnit);
   // function snapToGrid(sizeOfEachUnit: number) {
   //   const { transform } = sizeOfEachUnit;

--- a/src/components/InitialPuzzlePiece.tsx
+++ b/src/components/InitialPuzzlePiece.tsx
@@ -41,14 +41,17 @@ const InitialPuzzlePiece = ({
     const id = selectedPiece?.id;
     const pieceIndex = parseInt(id?.slice(id?.indexOf('-') + 1) ?? '0', 10);
     setIsRotating(true);
-    await animate(
-      scope.current,
-      { rotate: 90 },
-      { type: 'spring', stiffness: 150, damping: 11 }
-    );
-    updateDimensions(pieceIndex, selectedPiece?.height, selectedPiece.width);
-    await animate(scope.current, { rotate: 0 }, { duration: 0 });
-    setIsRotating(false);
+    try {
+      await animate(
+        scope.current,
+        { rotate: 90 },
+        { type: 'spring', stiffness: 150, damping: 11 }
+      );
+      updateDimensions(pieceIndex, selectedPiece.height, selectedPiece.width);
+      await animate(scope.current, { rotate: 0 }, { duration: 0 });
+    } finally {
+      setIsRotating(false);
+    }
     Hotjar.event('rotation');
   }
 
@@ -62,7 +65,8 @@ const InitialPuzzlePiece = ({
         {...attributes}
         onClick={handlePieceSelected}
         isDragging={isDragging}
-        layoutId={piece.id}
+        layout={!isRotating && !isDragging}
+        {...(!(isRotating && isSelected) ? { layoutId: piece.id } : {})}
       >
         <Rectangle
           width={piece.width}

--- a/src/components/PieceOnBoard.tsx
+++ b/src/components/PieceOnBoard.tsx
@@ -85,8 +85,8 @@ function PieceOnBoard({
     } finally {
       setIsRotating(false);
       const { x, y } = convertLocationToXAndY(selectedPiece.location);
-      let newX = x + Math.ceil(selectedPiece.height / 2) - 1;
-      let newY = y + Math.ceil(selectedPiece.width / 2) - 1;
+      let newX = x + Math.floor(selectedPiece.height / 2) - 1;
+      let newY = y + Math.floor(selectedPiece.width / 2) - 1;
       movePiece(pieceIndex, `(${newX},${newY})`);
     }
     Hotjar.event('rotation');

--- a/src/pages/game.tsx
+++ b/src/pages/game.tsx
@@ -183,7 +183,6 @@ export const PiecesContainer = styled(motion.div).attrs({
 })<{ $currentLevel: number }>`
   display: flex;
   flex-direction: row;
-  /* width: 700px; */
   flex-wrap: wrap;
   align-items: start;
   justify-content: right;


### PR DESCRIPTION
Fixed this by conditionally removing layoutId when the piece is selected and isRotating is true. 