### PR TITLE
Julianna/106 decouple piece index from updates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import Home from './pages/home';
 import About from './pages/about';
 import Math from './pages/math';

--- a/src/Game/ActionsToolbar/ActionsToolbarPopover.tsx
+++ b/src/Game/ActionsToolbar/ActionsToolbarPopover.tsx
@@ -1,4 +1,3 @@
-//@ts-no-check
 import { useContext } from 'react';
 import { Tooltip } from 'antd';
 import { motion } from 'motion/react';
@@ -29,7 +28,7 @@ function ActionsToolbarPopover({
 }: {
   children: React.ReactElement;
   runRotationAnimation: any;
-  delegated: any;
+  delegated?: any;
 }) {
   const context = useContext(PiecesInPlayContext);
   if (!context) {

--- a/src/Game/ActionsToolbar/ActionsToolbarPopover.tsx
+++ b/src/Game/ActionsToolbar/ActionsToolbarPopover.tsx
@@ -43,11 +43,14 @@ function ActionsToolbarPopover({
 
   function handleHorizontalStretch() {
     Hotjar.event('double width attempt');
-    const id = selectedPiece?.id;
+    if (!selectedPiece) {
+      return;
+    }
+    const id = selectedPiece.id;
     const isOnBoard =
-      selectedPiece?.location &&
-      selectedPiece?.location.match(/^\(\d+,\d+\)$/) &&
-      selectedPiece?.id?.startsWith('b-');
+      selectedPiece.location &&
+      selectedPiece.location.match(/^\(\d+,\d+\)$/) &&
+      selectedPiece.id.startsWith('b-');
     const stretchIsPossible =
       selectedPiece != null && Number.isInteger(selectedPiece.height / 2);
     if (stretchIsPossible) {
@@ -73,9 +76,9 @@ function ActionsToolbarPopover({
       const newWidth = selectedPiece.width / 2;
       const id = selectedPiece.id;
       const isOnBoard =
-        selectedPiece?.location &&
-        selectedPiece?.location.match(/^\(\d+,\d+\)$/) &&
-        selectedPiece?.id?.startsWith('b-');
+        selectedPiece.location &&
+        selectedPiece.location.match(/^\(\d+,\d+\)$/) &&
+        selectedPiece.id.startsWith('b-');
       if (isOnBoard) {
         updateLocationAndBoardSquares(
           selectedPiece,

--- a/src/Game/ActionsToolbar/ActionsToolbarPopover.tsx
+++ b/src/Game/ActionsToolbar/ActionsToolbarPopover.tsx
@@ -45,24 +45,22 @@ function ActionsToolbarPopover({
   function handleHorizontalStretch() {
     Hotjar.event('double width attempt');
     const id = selectedPiece?.id;
-    const pieceIndex = parseInt(id?.slice(id?.indexOf('-') + 1) ?? '0', 10);
+    const isOnBoard =
+      selectedPiece?.location &&
+      selectedPiece?.location.match(/^\(\d+,\d+\)$/) &&
+      selectedPiece?.id?.startsWith('b-');
     const stretchIsPossible =
       selectedPiece != null && Number.isInteger(selectedPiece.height / 2);
     if (stretchIsPossible) {
       const newHeight = selectedPiece.height / 2;
       const newWidth = selectedPiece.width * 2;
-      updateDimensions(pieceIndex, newWidth, newHeight);
-      if (
-        selectedPiece.location != null &&
-        selectedPiece.location != 'instructions' &&
-        selectedPiece.id != null
-      ) {
+      updateDimensions(id ?? 'invalidId', newWidth, newHeight);
+      if (isOnBoard) {
         updateLocationAndBoardSquares(
           selectedPiece,
           newWidth,
           newHeight,
-          movePiece,
-          pieceIndex
+          movePiece
         );
       }
       Hotjar.event('double width successfully');
@@ -75,21 +73,19 @@ function ActionsToolbarPopover({
       const newHeight = selectedPiece.height * 2;
       const newWidth = selectedPiece.width / 2;
       const id = selectedPiece.id;
-      const pieceIndex = parseInt(id?.slice(id?.indexOf('-') + 1) ?? '0', 10);
       const isOnBoard =
-        selectedPiece.location &&
-        selectedPiece.location.match(/^\(\d+,\d+\)$/) &&
-        selectedPiece.id?.startsWith('b-');
+        selectedPiece?.location &&
+        selectedPiece?.location.match(/^\(\d+,\d+\)$/) &&
+        selectedPiece?.id?.startsWith('b-');
       if (isOnBoard) {
         updateLocationAndBoardSquares(
           selectedPiece,
           newWidth,
           newHeight,
-          movePiece,
-          pieceIndex
+          movePiece
         );
       }
-      updateDimensions(pieceIndex, newWidth, newHeight);
+      updateDimensions(id ?? 'invalidId', newWidth, newHeight);
       Hotjar.event('double height successfully');
     }
   }
@@ -111,7 +107,9 @@ function ActionsToolbarPopover({
   const rotateDisabled = selectedPiece == null;
   return (
     <Popover withArrow trapFocus size="small" positioning="below">
-      <PopoverTrigger {...delegated}>{children}</PopoverTrigger>
+      <PopoverTrigger data-testid="actions-toolbar-trigger" {...delegated}>
+        {children}
+      </PopoverTrigger>
       <PopoverSurface id="actions">
         <ActionsToolbar>
           <Tooltip placement="bottom" title={showTooltips && 'Rotate'}>

--- a/src/Game/ActionsToolbar/useUpdateLocation.ts
+++ b/src/Game/ActionsToolbar/useUpdateLocation.ts
@@ -23,8 +23,7 @@ export function useUpdateLocation() {
     selectedPiece: Piece,
     newWidth: number,
     newHeight: number,
-    movePiece: (pieceIndex: number, newLocation: string | null) => void,
-    pieceIndex: number
+    movePiece: (pieceId: string, newLocation: string | null) => void
   ) => {
     const boardWidth = boardSquares[0].length;
     const boardHeight = boardSquares.length;
@@ -47,7 +46,10 @@ export function useUpdateLocation() {
         boardWidth,
         boardHeight
       );
-      movePiece(pieceIndex, `(${correctedX},${correctedY})`);
+      movePiece(
+        selectedPiece.id ?? 'invalidId',
+        `(${correctedX},${correctedY})`
+      );
       x = correctedX;
       y = correctedY;
     }
@@ -66,7 +68,7 @@ export function useUpdateLocation() {
       boardWidth,
       boardHeight
     );
-    movePiece(pieceIndex, `(${correctedX},${correctedY})`);
+    movePiece(selectedPiece.id ?? 'invalidId', `(${correctedX},${correctedY})`);
     x = correctedX;
     y = correctedY;
     addPieceToBoard(x, y, newWidth, newHeight, selectedPiece.id ?? '');

--- a/src/Game/DragAndDropArea.tsx
+++ b/src/Game/DragAndDropArea.tsx
@@ -147,16 +147,10 @@ function DragAndDropArea({
 
   const handleDragEnd = (event: DragEndEvent) => {
     const id = event.active.id as string;
-    const pieceIndex = parseInt(id.slice(id.indexOf('-') + 1), 10);
-    const { x, y } = convertLocationToXAndY(piecesInPlay[pieceIndex].location);
-    if (piecesInPlay[pieceIndex].location != null) {
-      removePieceFromBoard(
-        x,
-        y,
-        piecesInPlay[pieceIndex].width,
-        piecesInPlay[pieceIndex].height,
-        piecesInPlay[pieceIndex].id ?? ''
-      );
+    const piece = piecesInPlay.find(piece => piece.id === id);
+    if (piece?.location != null) {
+      const { x, y } = convertLocationToXAndY(piece.location);
+      removePieceFromBoard(x, y, piece?.width, piece?.height, piece?.id ?? '');
     }
     if (event?.over?.id) {
       const newLocation = event.over.id.toString();
@@ -166,20 +160,20 @@ function DragAndDropArea({
       const { correctedX, correctedY } = getNewValidLocation(
         x,
         y,
-        piecesInPlay[pieceIndex].width,
-        piecesInPlay[pieceIndex].height,
+        piece?.width,
+        piece?.height,
         boardWidth,
         boardHeight
       );
-      movePiece(pieceIndex, `(${correctedX},${correctedY})`);
+      movePiece(id, `(${correctedX},${correctedY})`);
       addPieceToBoard(
         correctedX,
         correctedY,
-        piecesInPlay[pieceIndex].width,
-        piecesInPlay[pieceIndex].height,
-        piecesInPlay[pieceIndex].id ?? ''
+        piece?.width,
+        piece?.height,
+        piece?.id ?? ''
       );
-    } else movePiece(pieceIndex, null);
+    } else movePiece(id, null);
     const unstablePieces = getUnstablePieces();
     piecesInPlay.forEach(piece => {
       if (unstablePieces.includes(piece.id ?? '')) {

--- a/src/Game/DragAndDropArea.tsx
+++ b/src/Game/DragAndDropArea.tsx
@@ -1,4 +1,4 @@
-import { useContext, useMemo } from 'react';
+import { useContext } from 'react';
 import {
   DndContext,
   useSensor,
@@ -10,7 +10,6 @@ import {
 } from '@dnd-kit/core';
 import type { DragStartEvent, DragEndEvent } from '@dnd-kit/core';
 // import { createSnapModifier } from '@dnd-kit/modifiers';
-// import { CurrentLevelContext } from '../context/CurrentLevel';
 import { PiecesInPlayContext } from '../context/PiecesInPlay';
 import { Piece } from '../types/piece';
 import { useSelectedPiece } from '../context/SelectedPiece';
@@ -83,18 +82,6 @@ function DragAndDropArea({
     return 'ontouchstart' in window || navigator.maxTouchPoints > 0;
   };
 
-  // const offsetTouch = (args: any) => {
-  //   const { transform } = args;
-  //   if (isTouchDevice() && transform) {
-  //     return {
-  //       ...transform,
-  //       x: transform.x + 20, // move slightly to the right
-  //       y: transform.y - 40, // move upward away from thumb
-  //     };
-  //   }
-  //   return transform;
-  // };
-
   // const snapToGrid = useMemo(
   //   () => createSnapModifier(sizeOfEachUnit),
   //   [sizeOfEachUnit]
@@ -149,7 +136,8 @@ function DragAndDropArea({
   const handleDragEnd = (event: DragEndEvent) => {
     const id = event.active.id as string;
     const piece = piecesInPlay.find(piece => piece.id === id);
-    if (piece?.location != null) {
+    if (!piece) return;
+    if (piece.location != null) {
       const { x, y } = convertLocationToXAndY(piece.location);
       removePieceFromBoard(x, y, piece?.width, piece?.height, piece?.id ?? '');
     }
@@ -161,8 +149,8 @@ function DragAndDropArea({
       const { correctedX, correctedY } = getNewValidLocation(
         x,
         y,
-        piece?.width,
-        piece?.height,
+        piece.width,
+        piece.height,
         boardWidth,
         boardHeight
       );
@@ -170,35 +158,32 @@ function DragAndDropArea({
       const { outerOverlaps, innerOverlaps, squaresOutsideBoard } =
         countOverlappingSquares(
           newLocation,
-          piece?.width ?? 0,
-          piece?.height ?? 0
+          piece.width ?? 0,
+          piece.height ?? 0
         );
-      console.log({ outerOverlaps, innerOverlaps, squaresOutsideBoard });
       if (outerOverlaps + innerOverlaps + squaresOutsideBoard > 0) {
         setPieceStability(id, false);
-        console.log('piece should be unstable now.');
       } else {
         setPieceStability(id, true);
       }
       addPieceToBoard(
         correctedX,
         correctedY,
-        piece?.width,
-        piece?.height,
-        piece?.id ?? ''
+        piece.width,
+        piece.height,
+        piece.id ?? ''
       );
     } else movePiece(id, null);
     const overlappingPieces = getOverlappingPieces();
     piecesInPlay.forEach(piece => {
-      if (piece.location === 'null' || piece.location === 'instructions')
-        return;
+      if (piece.location === null || piece.location === 'instructions') return;
       if (overlappingPieces.includes(piece.id ?? '')) {
-        setPieceStability(piece?.id, false);
+        setPieceStability(piece.id, false);
       } else {
         const { squaresOutsideBoard } = countOverlappingSquares(
-          piece?.location,
-          piece?.width ?? 0,
-          piece?.height ?? 0
+          piece.location,
+          piece.width ?? 0,
+          piece.height ?? 0
         );
         if (squaresOutsideBoard > 0) {
           setPieceStability(piece.id, false);
@@ -216,7 +201,6 @@ function DragAndDropArea({
       onDragStart={handleDragStart}
       onDragEnd={handleDragEnd}
       collisionDetection={customCollisionDetection}
-      // modifiers={[offsetTouch]}
     >
       {children}
     </DndContext>

--- a/src/Game/Instructions/InstructionsModal.tsx
+++ b/src/Game/Instructions/InstructionsModal.tsx
@@ -7,11 +7,13 @@ import SamplePiece from './SamplePiece';
 import { PiecesInPlayContext } from '../../context/PiecesInPlay';
 import MathematicalToolsRow from './MathematicalToolsRow';
 import ErrorBoundary from '../../components/ErrorBoundary';
+import { Piece } from '../../types/piece';
 
 const StyledDiv = styled.div`
   padding: '20px';
   width: '90px';
   margin-bottom: '90px';
+  margin-inline: '0px';
 
   @media screen and (max-width: 768px) {
     margin-bottom: '90px';
@@ -62,7 +64,7 @@ const InstructionsModal = ({
   const { updateDimensions } = context;
 
   const closeModal = () => {
-    updateDimensions(0, 3, 2); // Resetting the example piece to it's original dimensions
+    updateDimensions('sample-0', 3, 2); // Resetting the example piece to it's original dimensions
   };
 
   return (
@@ -103,7 +105,7 @@ const InstructionsModal = ({
           solutions.
         </StyledParagraph>
         <StyledH2>Try out the tools by clicking the piece below. </StyledH2>
-        <StyledDiv>
+        <StyledDiv data-testid="sample-piece-container">
           <ErrorBoundary>
             <SamplePiece
               piece={piecesInPlay[0]}

--- a/src/Game/Instructions/SamplePiece.tsx
+++ b/src/Game/Instructions/SamplePiece.tsx
@@ -37,7 +37,6 @@ const SamplePiece = ({
   }
 
   async function runRotationAnimation(selectedPiece) {
-    const pieceIndex = 0; // sample piece is always 0
     setIsRotating(true);
     try {
       await animate(
@@ -45,7 +44,7 @@ const SamplePiece = ({
         { rotate: 90 },
         { type: 'spring', stiffness: 150, damping: 11 }
       );
-      updateDimensions(pieceIndex, selectedPiece.height, selectedPiece.width);
+      updateDimensions('sample-0', selectedPiece.height, selectedPiece.width);
       await animate(scope.current, { rotate: 0 }, { duration: 0 });
     } finally {
       setIsRotating(false);
@@ -56,7 +55,10 @@ const SamplePiece = ({
   const isSelected = selectedPiece?.id === piece.id;
 
   return (
-    <ActionsToolbarPopover runRotationAnimation={runRotationAnimation}>
+    <ActionsToolbarPopover
+      data-testid={`actions-toolbar-trigger`}
+      runRotationAnimation={runRotationAnimation}
+    >
       <SamplePieceWrapper
         ref={scope}
         data-testid={piece.id}
@@ -81,9 +83,10 @@ export const SamplePieceWrapper = styled(motion.button)`
   border: none;
   z-index: 2;
   border: 2px solid black;
-  margin: 0;
   margin-bottom: 30px;
+  margin-left: 20px;
   margin-top: 10px;
+  place-self: center;
   &:active {
     cursor: grab;
   }

--- a/src/Game/PlacedPieces.tsx
+++ b/src/Game/PlacedPieces.tsx
@@ -18,11 +18,9 @@ function PlacedPieces({
         piece.id != 'sample-0' ? (
           <PieceOnBoard
             piece={piece}
-            id={`b-${index}`}
             key={`b-${index}`}
             isRotating={isRotating}
             setIsRotating={setIsRotating}
-            isStable={piece.isStable ?? true}
           />
         ) : null
       )}

--- a/src/Game/PlacedPieces.tsx
+++ b/src/Game/PlacedPieces.tsx
@@ -12,13 +12,13 @@ function PlacedPieces({
 }) {
   return (
     <PlacedPiecesWrapper>
-      {piecesInPlay.map((piece, index) =>
+      {piecesInPlay.map(piece =>
         piece.location != null &&
         piece.location != 'instructions' &&
         piece.id != 'sample-0' ? (
           <PieceOnBoard
             piece={piece}
-            key={`b-${index}`}
+            key={piece.id}
             isRotating={isRotating}
             setIsRotating={setIsRotating}
           />

--- a/src/Game/PuzzlePieces/InitialPuzzlePiece.tsx
+++ b/src/Game/PuzzlePieces/InitialPuzzlePiece.tsx
@@ -52,7 +52,7 @@ const InitialPuzzlePiece = ({
         { rotate: 90 },
         { type: 'spring', stiffness: 150, damping: 11 }
       );
-      updateDimensions(pieceIndex, selectedPiece.height, selectedPiece.width);
+      updateDimensions(piece.id, selectedPiece.height, selectedPiece.width);
       await animate(scope.current, { rotate: 0 }, { duration: 0 });
     } finally {
       setIsRotating(false);

--- a/src/Game/PuzzlePieces/PieceOnBoard.tsx
+++ b/src/Game/PuzzlePieces/PieceOnBoard.tsx
@@ -103,7 +103,7 @@ function PieceOnBoard({
         { rotate: 90 },
         { type: 'spring', stiffness: 150, damping: 11 }
       );
-      updateDimensions(pieceIndex, newWidth, newHeight);
+      updateDimensions(piece.id, newWidth, newHeight);
       await animate(scope.current, { rotate: 0 }, { duration: 0 });
     } finally {
       setIsRotating(false);
@@ -120,7 +120,7 @@ function PieceOnBoard({
         boardHeight
       );
 
-      movePiece(pieceIndex, `(${correctedX},${correctedY})`);
+      movePiece(piece.id, `(${correctedX},${correctedY})`);
       addPieceToBoard(
         correctedX,
         correctedY,

--- a/src/Game/PuzzlePieces/PieceOnBoard.tsx
+++ b/src/Game/PuzzlePieces/PieceOnBoard.tsx
@@ -54,13 +54,14 @@ function PieceOnBoard({
   piece,
   isRotating,
   setIsRotating,
-  isStable = true,
-}: {
+}: // isStable = true,
+{
   piece: Piece;
   isRotating: boolean;
   setIsRotating: (isRotating: boolean) => void;
-  isStable: boolean;
+  // isStable: boolean;
 }) {
+  const isStable = piece.isStable;
   const { selectedPiece, setSelectedPiece } =
     useContext<SelectedPieceContextType>(SelectedPieceContext);
   const { piecesInPlay, updateDimensions, movePiece } =
@@ -80,9 +81,8 @@ function PieceOnBoard({
   const refs = mergeRefs(scope, setNodeRef);
   const isSelected = selectedPiece?.id === piece.id;
 
-  /* This function lives here instead of ActionsToolbar for three reasons
-  1. It needs to be access to the scope ref that's attached to the PieceWrapper and that would require ref forwarding to put it in the ActionsToolbarPopover
-  2. It needs access to setIsRotating 
+  /* This function lives here instead of ActionsToolbar for two reasons
+  1. It needs to be access to the scope ref that's attached to the PieceWrapper and that would be very complicated to pass to ActionsToolbarPopover. I would need to pass the ref upward to it's parent and I can't create the ref in ActionsToolbar and then pass it down through {children}. And since I'm using mergeRefs to attach two different refs to the PieceWrapper, I can't use a callback Ref. 
   3. There is additional logic for PieceOnBoard rotations to adjust the piece location after the rotation to make it appear to rotate around the center. 
   */
   async function runRotationAnimation(selectedPiece) {

--- a/src/Game/PuzzlePieces/PieceOnBoard.tsx
+++ b/src/Game/PuzzlePieces/PieceOnBoard.tsx
@@ -1,10 +1,9 @@
-// @ts-nocheck
 import { useDraggable } from '@dnd-kit/core';
 import { mergeRefs } from '@chakra-ui/react';
 import Rectangle from '../Rectangle';
 import ActionsToolbarPopover from '../ActionsToolbar/ActionsToolbarPopover';
 import { useState, memo, useContext } from 'react';
-import { motion, useAnimate } from 'motion/react';
+import { motion, useAnimate, HTMLMotionProps } from 'motion/react';
 import styled from 'styled-components';
 import { convertLocationToXAndY } from '../utils/utilities';
 import { Piece } from '../../types/piece';
@@ -27,6 +26,13 @@ import {
 } from '../../context/BoardSquares';
 import { getNewValidLocation } from '../utils/getNewValidLocation';
 
+interface PieceWrapperProps extends HTMLMotionProps<'button'> {
+  x: number;
+  y: number;
+  isDragging?: boolean;
+  isSelected?: boolean;
+}
+
 export const PieceWrapper = styled(motion.button)
   .withConfig({
     shouldForwardProp: prop => prop !== 'isDragging' && prop !== 'isSelected',
@@ -36,7 +42,7 @@ export const PieceWrapper = styled(motion.button)
     ref: props.ref,
     animate: props.animate,
     transition: props.transition,
-  }))`
+  }))<PieceWrapperProps>`
   position: absolute;
   left: ${({ x }) => `calc(${x} * var(--sizeOfEachUnit) - 2px)`};
   top: ${({ y }) => `calc(${y} * var(--sizeOfEachUnit) - 2px)`};
@@ -54,40 +60,40 @@ function PieceOnBoard({
   piece,
   isRotating,
   setIsRotating,
-}: // isStable = true,
-{
+}: {
   piece: Piece;
   isRotating: boolean;
   setIsRotating: (isRotating: boolean) => void;
-  // isStable: boolean;
 }) {
   const isStable = piece.isStable;
-  const { selectedPiece, setSelectedPiece } =
-    useContext<SelectedPieceContextType>(SelectedPieceContext);
-  const { piecesInPlay, updateDimensions, movePiece } =
-    useContext<PiecesInPlayContextType>(PiecesInPlayContext);
-  const { sizeOfEachUnit, boardDimensions } =
-    useContext<CurrentLevelContextType>(CurrentLevelContext);
-  const { addPieceToBoard, removePieceFromBoard } =
-    useContext<BoardSquaresContextType>(BoardSquaresContext);
+  const selectedPieceContext = useContext(SelectedPieceContext);
+  const piecesInPlayContext = useContext(PiecesInPlayContext);
+  const currentLevelContext = useContext(CurrentLevelContext);
+  const boardSquaresContext = useContext(BoardSquaresContext);
+
+  if (!selectedPieceContext || !piecesInPlayContext || !boardSquaresContext) {
+    throw new Error('PieceOnBoard must be used within all required providers');
+  }
+
+  const { selectedPiece, setSelectedPiece } = selectedPieceContext;
+  const { piecesInPlay, updateDimensions, movePiece } = piecesInPlayContext;
+  const { boardDimensions } = currentLevelContext;
+  const { addPieceToBoard, removePieceFromBoard } = boardSquaresContext;
   const [scope, animate] = useAnimate();
 
   const { x, y } = convertLocationToXAndY(piece.location);
 
-  const { attributes, isDragging, listeners, setNodeRef, transform } =
-    useDraggable({
-      id: piece.id,
-    });
+  const { attributes, isDragging, listeners, setNodeRef } = useDraggable({
+    id: piece.id,
+  });
   const refs = mergeRefs(scope, setNodeRef);
   const isSelected = selectedPiece?.id === piece.id;
 
-  /* This function lives here instead of ActionsToolbar for two reasons
+  /* This rotation animation function lives here instead of ActionsToolbar for two reasons
   1. It needs to be access to the scope ref that's attached to the PieceWrapper and that would be very complicated to pass to ActionsToolbarPopover. I would need to pass the ref upward to it's parent and I can't create the ref in ActionsToolbar and then pass it down through {children}. And since I'm using mergeRefs to attach two different refs to the PieceWrapper, I can't use a callback Ref. 
   3. There is additional logic for PieceOnBoard rotations to adjust the piece location after the rotation to make it appear to rotate around the center. 
   */
-  async function runRotationAnimation(selectedPiece) {
-    const id = selectedPiece?.id;
-    const pieceIndex = parseInt(id?.slice(id?.indexOf('-') + 1) ?? '0', 10);
+  async function runRotationAnimation(selectedPiece: Piece) {
     const { x, y } = convertLocationToXAndY(selectedPiece.location);
     const oldWidth = selectedPiece.width;
     const oldHeight = selectedPiece.height;
@@ -136,7 +142,7 @@ function PieceOnBoard({
     const chosenPiece = piecesInPlay.find(
       (pieceInList: Piece) => piece.id === pieceInList.id
     );
-    setSelectedPiece(chosenPiece);
+    setSelectedPiece(chosenPiece ?? null);
     Hotjar.event(
       `board piece selected width:${piece.width} height:${piece.height}`
     );
@@ -150,12 +156,11 @@ function PieceOnBoard({
         {...attributes}
         onClick={handlePieceSelected}
         data-testid={piece.id}
-        x={x}
-        y={y}
+        x={x as number}
+        y={y as number}
         layout={!isRotating && !isDragging && !isStable}
         isDragging={isDragging}
         isSelected={isSelected}
-        isStable={isStable}
         animate={
           isStable
             ? { x: 0, y: 0 }

--- a/src/Game/utils/getInitialPieces.ts
+++ b/src/Game/utils/getInitialPieces.ts
@@ -1,10 +1,10 @@
-import { InitialPiece } from '../../types/piece';
+import { Piece } from '../../types/piece';
 import levels from '../levels.json' assert { type: 'json' };
 import { colors } from '../../CONSTANTS';
 
 const initialLocation = null;
 
-export function getInitialPieces(level: number): InitialPiece[] {
+export function getInitialPieces(level: number): Piece[] {
   return [
     {
       width: 3,

--- a/src/Game/utils/getInitialPieces.ts
+++ b/src/Game/utils/getInitialPieces.ts
@@ -13,6 +13,7 @@ export function getInitialPieces(level: number): InitialPiece[] {
       color: 'hsl(0, 61%, 66%)',
       id: 'sample-0',
       isRotated: false,
+      isStable: true,
     },
     ...levels[level].pieces.map((piece, index) => ({
       ...piece,
@@ -20,6 +21,7 @@ export function getInitialPieces(level: number): InitialPiece[] {
       color: colors[index % colors.length],
       id: `i-${index + 1}`,
       isRotated: false,
+      isStable: true,
     })),
   ];
 }

--- a/src/Game/utils/utilities.ts
+++ b/src/Game/utils/utilities.ts
@@ -1,4 +1,4 @@
-import { Piece } from '../types/piece';
+import { Piece } from '../../types/piece';
 
 export function updatePiecesInPlay() {
   /**  check if puzzle piece was already placed on the board 
@@ -77,48 +77,10 @@ export function findLargestHeight(
   return Math.max(...heights);
 }
 
-// export function updateLocationForCollision(
-//   location: string,
-//   pieceWidth: number,
-//   pieceHeight: number,
-//   // boardWidth: number,
-//   // boardHeight: number,
-//   boardSquares: string[][]
-// ) {
-//   let updatedLocation = location;
-
-//   const { outerOverlaps, innerOverlaps } = countOverlappingSquares(
-//     location,
-//     pieceWidth,
-//     pieceHeight,
-//     boardSquares
-//   );
-
-//   if (innerOverlaps > 0) return null;
-
-//   /* Count total potentially overlapping squares.
-
-//   if rightmost column of piece is overlapping by 1 column with more than 1 overlapping square AND IF there is empty space to the left, shift one unit to the left.
-//         Check if there are still some squares with an overlap
-//         IF not, early return
-//   else If rightmost column of piece is overlapping by 1 column with more than 1 overlapping square AND IF there is empty space to the right, shift one unit to the right.
-//         Check if there are still some squares with an overlap
-//         IF not, early return
-
-//  if topmost row of piece is overlapping by 1 column AND IF there is empty space below , shift one unit down
-//         Check if there are still some squares with an overlap
-//         IF not, early return
-//  else if bottom-most row of piece is overlapping by 1 AND IF there is empty space below, shift one unit up
-//         Check if there are still some squares with an overlap
-//         IF not, early return
-
-//     return null (which means it will go back to the intial pieces container)
-
-//  */
-
-//   return updatedLocation;
-// }
-
 export function findPieceById(piecesInPlay: Piece[], id: string) {
   return piecesInPlay.find(piece => piece.id === id);
+}
+
+export function getPieceNumber(id: string) {
+  return parseInt(id.slice(id.indexOf('-') + 1), 10);
 }

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -138,14 +138,18 @@ function Modal({
     </RemoveScroll>
   );
 
-  return (
+  const dialogWithTrigger = trigger ? (
     <Dialog modalType={modalType} open={open} onOpenChange={handleOpenChange}>
-      {trigger && (
-        <DialogTrigger disableButtonEnhancement>{trigger}</DialogTrigger>
-      )}
+      <DialogTrigger disableButtonEnhancement>{trigger}</DialogTrigger>
+      {dialogContent}
+    </Dialog>
+  ) : (
+    <Dialog modalType={modalType} open={open} onOpenChange={handleOpenChange}>
       {dialogContent}
     </Dialog>
   );
+
+  return dialogWithTrigger;
 }
 
 export default Modal;

--- a/src/context/BoardSquares.tsx
+++ b/src/context/BoardSquares.tsx
@@ -1,10 +1,12 @@
-//@ts-nocheck
 import { createContext, useContext, useState, ReactNode } from 'react';
 import levels from '../Game/levels.json';
 import { getInitialBoardSquares } from '../Game/utils/getInitialBoardSquares';
-import { CurrentLevelContext } from './CurrentLevel.tsx';
+import { CurrentLevelContext } from './CurrentLevel';
 import { convertLocationToXAndY } from '../Game/utils/utilities';
-import { LevelProgressContext } from './LevelProgress.tsx';
+import {
+  LevelProgressContext,
+  LevelProgressContextType,
+} from './LevelProgress';
 import Hotjar from '@hotjar/browser';
 
 export type BoardSquaresContextType = {
@@ -43,7 +45,13 @@ export const BoardSquaresContext =
 
 export function BoardSquaresProvider({ children }: { children: ReactNode }) {
   const { currentLevel } = useContext(CurrentLevelContext);
-  const { setLevelCompleted } = useContext(LevelProgressContext);
+  const levelProgressContext = useContext(LevelProgressContext);
+  if (!levelProgressContext) {
+    throw new Error(
+      'LevelProgressContext must be used within a LevelProgressProvider'
+    );
+  }
+  const { setLevelCompleted } = levelProgressContext;
   const [boardSquares, setBoardSquares] = useState<string[][]>(
     getInitialBoardSquares(currentLevel)
   );
@@ -160,7 +168,7 @@ export function BoardSquaresProvider({ children }: { children: ReactNode }) {
   }
 
   function getOverlappingPieces() {
-    const overlappingPieces = [];
+    const overlappingPieces: string[] = [];
     for (let row = 0; row < boardSquares.length; row++) {
       for (let col = 0; col < boardSquares[row].length; col++) {
         if (boardSquares[row][col]?.length > 0) {

--- a/src/context/BoardSquares.tsx
+++ b/src/context/BoardSquares.tsx
@@ -156,7 +156,6 @@ export function BoardSquaresProvider({ children }: { children: ReactNode }) {
         }
       }
     }
-    console.log(boardSquares);
     return { outerOverlaps, innerOverlaps, squaresOutsideBoard };
   }
 

--- a/src/context/BoardSquares.tsx
+++ b/src/context/BoardSquares.tsx
@@ -34,7 +34,7 @@ export type BoardSquaresContextType = {
     innerOverlaps: number;
     squaresOutsideBoard: number;
   };
-  getUnstablePieces: () => string[];
+  getOverlappingPieces: () => string[];
   checkIfPassedLevel: () => boolean;
 };
 
@@ -156,26 +156,27 @@ export function BoardSquaresProvider({ children }: { children: ReactNode }) {
         }
       }
     }
+    console.log(boardSquares);
     return { outerOverlaps, innerOverlaps, squaresOutsideBoard };
   }
 
-  function getUnstablePieces() {
-    const unstablePieces = [];
+  function getOverlappingPieces() {
+    const overlappingPieces = [];
     for (let row = 0; row < boardSquares.length; row++) {
       for (let col = 0; col < boardSquares[row].length; col++) {
         if (boardSquares[row][col]?.length > 0) {
           const ids = boardSquares[row][col].split(', ').map(id => id.trim());
           if (ids.length > 1) {
             ids.forEach(id => {
-              if (!unstablePieces.includes(id)) {
-                unstablePieces.push(id);
+              if (!overlappingPieces.includes(id)) {
+                overlappingPieces.push(id);
               }
             });
           }
         }
       }
     }
-    return unstablePieces;
+    return overlappingPieces;
   }
 
   function countEmptySquares() {
@@ -191,7 +192,7 @@ export function BoardSquaresProvider({ children }: { children: ReactNode }) {
   }
 
   function checkIfPassedLevel() {
-    const unstablePieces = getUnstablePieces();
+    const unstablePieces = getOverlappingPieces();
     const noOverlaps = unstablePieces.length === 0;
     const noEmptySquares = countEmptySquares() === 0;
     if (noOverlaps && noEmptySquares) {
@@ -208,7 +209,7 @@ export function BoardSquaresProvider({ children }: { children: ReactNode }) {
         removePieceFromBoard,
         resetBoardSquares,
         countOverlappingSquares,
-        getUnstablePieces,
+        getOverlappingPieces,
         checkIfPassedLevel,
       }}
     >

--- a/src/context/BoardSquares.tsx
+++ b/src/context/BoardSquares.tsx
@@ -36,7 +36,7 @@ export type BoardSquaresContextType = {
     innerOverlaps: number;
     squaresOutsideBoard: number;
   };
-  getOverlappingPieces: () => string[];
+  getUnstablePieces: () => string[];
   checkIfPassedLevel: () => boolean;
 };
 
@@ -167,7 +167,7 @@ export function BoardSquaresProvider({ children }: { children: ReactNode }) {
     return { outerOverlaps, innerOverlaps, squaresOutsideBoard };
   }
 
-  function getOverlappingPieces() {
+  function getUnstablePieces() {
     const overlappingPieces: string[] = [];
     for (let row = 0; row < boardSquares.length; row++) {
       for (let col = 0; col < boardSquares[row].length; col++) {
@@ -199,7 +199,7 @@ export function BoardSquaresProvider({ children }: { children: ReactNode }) {
   }
 
   function checkIfPassedLevel() {
-    const unstablePieces = getOverlappingPieces();
+    const unstablePieces = getUnstablePieces();
     const noOverlaps = unstablePieces.length === 0;
     const noEmptySquares = countEmptySquares() === 0;
     if (noOverlaps && noEmptySquares) {
@@ -216,7 +216,7 @@ export function BoardSquaresProvider({ children }: { children: ReactNode }) {
         removePieceFromBoard,
         resetBoardSquares,
         countOverlappingSquares,
-        getOverlappingPieces,
+        getUnstablePieces,
         checkIfPassedLevel,
       }}
     >

--- a/src/context/CurrentLevel.tsx
+++ b/src/context/CurrentLevel.tsx
@@ -4,13 +4,13 @@ import { colors } from '../CONSTANTS';
 export const CurrentLevelContext = createContext<CurrentLevelContextType>(
   {} as CurrentLevelContextType
 );
-import { InitialPiece } from '../types/piece';
+import { Piece } from '../types/piece';
 import { calculateUnitSize, findLargestHeight } from '../Game/utils/utilities';
 import Hotjar from '@hotjar/browser';
 
 export interface CurrentLevelContextType {
   currentLevel: number;
-  initialPieces: InitialPiece[];
+  initialPieces: Piece[];
   boardDimensions: { boardWidth: number; boardHeight: number };
   levelPosition: 'first' | 'middle' | 'last';
   levelId: number;
@@ -19,10 +19,6 @@ export interface CurrentLevelContextType {
   previousLevel: () => void;
   setCurrentLevel: (level: number) => void;
 }
-
-// export const CurrentLevelContext = createContext<CurrentLevelContextType>(
-//   {} as CurrentLevelContextType
-// );
 
 const initialLocation = null;
 const numberOfLevels = levels.length;
@@ -141,6 +137,7 @@ export function CurrentLevelProvider({ children }: CurrentLevelProviderProps) {
           previousLevel,
           setCurrentLevel,
         } as CurrentLevelContextType
+        // maybe I should export these (top 6) as a named object instead of separate variables. 
       }
     >
       {children}

--- a/src/context/PiecesInPlay.test.tsx
+++ b/src/context/PiecesInPlay.test.tsx
@@ -1,0 +1,327 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PiecesInPlayProvider, PiecesInPlayContext } from './PiecesInPlay';
+import { CurrentLevelContext } from './CurrentLevel';
+import { BoardSquaresContext } from './BoardSquares';
+import { Piece } from '../types/piece';
+import { useContext, useEffect } from 'react';
+
+// Mock dependencies
+vi.mock('@hotjar/browser', () => ({
+  default: {
+    event: vi.fn(),
+  },
+}));
+
+vi.mock('../Game/utils/utilities', () => ({
+  convertLocationToXAndY: vi.fn(location => {
+    if (location === '(1,2)') return { x: 1, y: 2 };
+    if (location === '(0,0)') return { x: 0, y: 0 };
+    return { x: 0, y: 0 };
+  }),
+  getPieceNumber: vi.fn(id => {
+    const match = id.match(/\d+/);
+    return match ? parseInt(match[0]) : 0;
+  }),
+}));
+
+vi.mock('../Game/utils/getNewValidLocation', () => ({
+  getNewValidLocation: vi.fn(
+    (x, y, width, height, boardWidth, boardHeight) => ({
+      correctedX: Math.max(0, Math.min(x, boardWidth - width)),
+      correctedY: Math.max(0, Math.min(y, boardHeight - height)),
+    })
+  ),
+}));
+
+// Test component to access context
+function TestComponent({ onContext }: { onContext: (context: any) => void }) {
+  const context = useContext(PiecesInPlayContext);
+  useEffect(() => {
+    if (context) {
+      onContext(context);
+    }
+  }, [context, onContext]);
+  return <div>Test</div>;
+}
+
+describe('PiecesInPlay updateDimensions', () => {
+  let mockContext: any;
+  let mockPiecesInPlay: Piece[];
+
+  const mockCurrentLevelContext = {
+    currentLevel: 0,
+    initialPieces: [
+      {
+        id: 'sample-0',
+        width: 3,
+        height: 2,
+        location: 'instructions',
+        color: 'hsl(0, 61%, 66%)',
+        isRotated: false,
+      },
+      {
+        id: 'i-1',
+        width: 2,
+        height: 3,
+        location: null,
+        color: 'red',
+        isRotated: false,
+      },
+      {
+        id: 'b-2',
+        width: 1,
+        height: 2,
+        location: '(1,2)',
+        color: 'blue',
+        isRotated: false,
+      },
+    ],
+    boardDimensions: { boardWidth: 5, boardHeight: 5 },
+    levelId: 1,
+    levelPosition: 'middle' as const,
+    sizeOfEachUnit: 1,
+    previousLevel: vi.fn(),
+    nextLevel: vi.fn(),
+    setSizeOfEachUnit: vi.fn(),
+    setCurrentLevel: vi.fn(),
+  };
+
+  const mockBoardSquaresContext = {
+    boardSquares: Array(5)
+      .fill(null)
+      .map(() => Array(5).fill('')),
+    setBoardSquares: vi.fn(),
+    addPieceToBoard: vi.fn(),
+    removePieceFromBoard: vi.fn(),
+    resetBoardSquares: vi.fn(),
+    countOverlappingSquares: vi.fn(() => ({
+      outerOverlaps: 0,
+      innerOverlaps: 0,
+      squaresOutsideBoard: 0,
+    })),
+    getUnstablePieces: vi.fn(() => []),
+    checkIfPassedLevel: vi.fn(() => false),
+  };
+
+  beforeEach(() => {
+    mockPiecesInPlay = [
+      {
+        id: 'sample-0',
+        width: 3,
+        height: 2,
+        location: 'instructions',
+        color: 'hsl(0, 61%, 66%)',
+        isRotated: false,
+      },
+      {
+        id: 'i-1',
+        width: 2,
+        height: 3,
+        location: null,
+        color: 'red',
+        isRotated: false,
+      },
+      {
+        id: 'b-2',
+        width: 1,
+        height: 2,
+        location: '(1,2)',
+        color: 'blue',
+        isRotated: false,
+      },
+    ] as Piece[];
+
+    const freshMockCurrentLevelContext = {
+      ...mockCurrentLevelContext,
+      initialPieces: mockPiecesInPlay as any, // Cast to avoid type issues in test
+    };
+
+    render(
+      <CurrentLevelContext.Provider value={freshMockCurrentLevelContext}>
+        <BoardSquaresContext.Provider value={mockBoardSquaresContext}>
+          <PiecesInPlayProvider>
+            <TestComponent
+              onContext={context => {
+                mockContext = context;
+              }}
+            />
+          </PiecesInPlayProvider>
+        </BoardSquaresContext.Provider>
+      </CurrentLevelContext.Provider>
+    );
+  });
+
+  // Helper function to wait for state updates
+  const waitForUpdate = () => new Promise(resolve => setTimeout(resolve, 0));
+
+  describe('Valid piece updates', () => {
+    it('should update dimensions for a valid piece ID', async () => {
+      const pieceId = 'i-1';
+      const newWidth = 4;
+      const newHeight = 2;
+
+      mockContext.updateDimensions(pieceId, newWidth, newHeight);
+      await waitForUpdate();
+
+      const updatedPiece = mockContext.piecesInPlay.find(
+        (p: Piece) => p.id === pieceId
+      );
+      expect(updatedPiece).toBeDefined();
+      expect(updatedPiece.width).toBe(newWidth);
+      expect(updatedPiece.height).toBe(newHeight);
+    });
+
+    it('should update dimensions for a board piece', async () => {
+      const pieceId = 'b-2';
+      const newWidth = 3;
+      const newHeight = 1;
+
+      mockContext.updateDimensions(pieceId, newWidth, newHeight);
+      await waitForUpdate();
+
+      const updatedPiece = mockContext.piecesInPlay.find(
+        (p: Piece) => p.id === pieceId
+      );
+      expect(updatedPiece).toBeDefined();
+      expect(updatedPiece.width).toBe(newWidth);
+      expect(updatedPiece.height).toBe(newHeight);
+    });
+
+    it('should preserve other piece properties when updating dimensions', () => {
+      const pieceId = 'i-1';
+      const originalPiece = mockContext.piecesInPlay.find(
+        (p: Piece) => p.id === pieceId
+      );
+      const newWidth = 5;
+      const newHeight = 3;
+
+      mockContext.updateDimensions(pieceId, newWidth, newHeight);
+
+      const updatedPiece = mockContext.piecesInPlay.find(
+        (p: Piece) => p.id === pieceId
+      );
+      expect(updatedPiece.id).toBe(originalPiece.id);
+      expect(updatedPiece.location).toBe(originalPiece.location);
+      expect(updatedPiece.color).toBe(originalPiece.color);
+      expect(updatedPiece.isRotated).toBe(originalPiece.isRotated);
+    });
+
+    it('should not affect other pieces when updating one piece', () => {
+      const pieceId = 'i-1';
+      const otherPieceId = 'b-2';
+      const originalOtherPiece = mockContext.piecesInPlay.find(
+        (p: Piece) => p.id === otherPieceId
+      );
+
+      mockContext.updateDimensions(pieceId, 4, 2);
+
+      const unchangedPiece = mockContext.piecesInPlay.find(
+        (p: Piece) => p.id === otherPieceId
+      );
+      expect(unchangedPiece.width).toBe(originalOtherPiece.width);
+      expect(unchangedPiece.height).toBe(originalOtherPiece.height);
+    });
+  });
+
+  describe('Invalid piece ID handling', () => {
+    it('should log error and return early for non-existent piece ID', () => {
+      const consoleSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const pieceId = 'non-existent-id';
+      const newWidth = 4;
+      const newHeight = 2;
+
+      mockContext.updateDimensions(pieceId, newWidth, newHeight);
+
+      expect(consoleSpy).toHaveBeenCalledWith('Piece not found');
+      expect(mockContext.piecesInPlay).toEqual(mockPiecesInPlay); // No changes
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should handle empty string piece ID', () => {
+      const consoleSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const pieceId = '';
+      const newWidth = 4;
+      const newHeight = 2;
+
+      mockContext.updateDimensions(pieceId, newWidth, newHeight);
+
+      expect(consoleSpy).toHaveBeenCalledWith('Piece not found');
+      consoleSpy.mockRestore();
+    });
+
+    it('should handle null piece ID', () => {
+      const consoleSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      const pieceId = null as any;
+      const newWidth = 4;
+      const newHeight = 2;
+
+      mockContext.updateDimensions(pieceId, newWidth, newHeight);
+
+      expect(consoleSpy).toHaveBeenCalledWith('Piece not found');
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('Multiple updates', () => {
+    it('should handle multiple consecutive updates to the same piece', async () => {
+      const pieceId = 'b-2';
+
+      const piece1Before = mockContext.piecesInPlay.find(
+        (p: Piece) => p.id === pieceId
+      );
+      expect(piece1Before.width).toBe(1); // Original width
+      expect(piece1Before.height).toBe(2); // Original height
+
+      await mockContext.updateDimensions(pieceId, 3, 4);
+      await mockContext.updateDimensions(pieceId, 5, 2);
+      await mockContext.updateDimensions(pieceId, 1, 1);
+
+      const piece1 = mockContext.piecesInPlay.find(
+        (p: Piece) => p.id === 'i-1'
+      );
+      const piece2 = mockContext.piecesInPlay.find(
+        (p: Piece) => p.id === 'b-2'
+      );
+      expect(piece1.width).toBe(2);
+      expect(piece1.height).toBe(3);
+      expect(piece2.width).toBe(1);
+      expect(piece2.height).toBe(1);
+    });
+
+    it('should handle updates to different pieces', async () => {
+      // Get pieces before updates
+      const piece1Before = mockContext.piecesInPlay.find(
+        (p: Piece) => p.id === 'i-1'
+      );
+      expect(piece1Before.width).toBe(2); // Original width
+      expect(piece1Before.height).toBe(3); // Original width
+
+      const piece2Before = mockContext.piecesInPlay.find(
+        (p: Piece) => p.id === 'b-2'
+      );
+      expect(piece2Before.width).toBe(1); // Original width
+      expect(piece2Before.height).toBe(2); // Original width
+
+      await mockContext.updateDimensions('i-1', 3, 4);
+      await mockContext.updateDimensions('b-2', 2, 3);
+      const piece1 = mockContext.piecesInPlay.find(
+        (p: Piece) => p.id === 'i-1'
+      );
+      const piece2 = mockContext.piecesInPlay.find(
+        (p: Piece) => p.id === 'b-2'
+      );
+      expect(piece1.width).toBe(3);
+      expect(piece1.height).toBe(4);
+      expect(piece2.width).toBe(2);
+      expect(piece2.height).toBe(3);
+    });
+  });
+});

--- a/src/context/PiecesInPlay.tsx
+++ b/src/context/PiecesInPlay.tsx
@@ -19,11 +19,12 @@ import { X } from 'lucide-react';
 
 export interface PiecesInPlayContextType {
   piecesInPlay: Piece[];
-  movePiece: (pieceIndex: number, newLocation: string | null) => void;
-  updateDimensions: (pieceIndex: number, width: number, height: number) => void;
+  movePiece: (pieceId: string, newLocation: string | null) => void;
+  updateDimensions: (pieceId: string, width: number, height: number) => void;
   rotatePiece: (pieceIndex: number) => void;
   resetPieces: () => void;
   setPiecesForNewLevel: (newPieces?: InitialPiece[]) => void;
+  setPieceStability: (pieceId: string, isStable: boolean) => void;
 }
 
 export const PiecesInPlayContext =
@@ -49,7 +50,7 @@ export function PiecesInPlayProvider({
   );
   const { boardWidth, boardHeight } = boardDimensions;
 
-  function movePiece(pieceId, newLocation: string | null) {
+  function movePiece(pieceId: string, newLocation: string | null) {
     const pieceIndex = piecesInPlay.findIndex(piece => piece.id === pieceId);
     const updatedPieces = [...piecesInPlay];
     const oldLocation = piecesInPlay[pieceIndex].location;
@@ -91,7 +92,7 @@ export function PiecesInPlayProvider({
     }
   }
 
-  function updateDimensions(pieceId: number, width: number, height: number) {
+  function updateDimensions(pieceId: string, width: number, height: number) {
     const pieceIndex = piecesInPlay.findIndex(piece => piece.id === pieceId);
     if (pieceIndex === -1) {
       console.error('Piece not found');
@@ -143,6 +144,41 @@ export function PiecesInPlayProvider({
   function setPiecesForNewLevel(newPieces?: InitialPiece[]) {
     setPiecesInPlay(newPieces || initialPieces);
   }
+
+  function setPieceStability(pieceId: string, isStable: boolean) {
+    // if pieceId starts with i-${num} create a constant called onBoardId and set it to b-${num}
+    const iPattern = /^i-(\d+)$/;
+    const match = pieceId.match(iPattern);
+    if (match) {
+      const num = match[1];
+      const onBoardId = `b-${num}`;
+    }
+    
+    // Extract the number from pieceId (removes i- or b- prefix)
+    const numberPattern = /^[ib]-(\d+)$/;
+    const numberMatch = pieceId.match(numberPattern);
+    if (!numberMatch) {
+      console.error('Invalid pieceId format');
+      return;
+    }
+    const pieceNumber = numberMatch[1];
+    
+    // Find piece by number (ignoring prefix)
+    const pieceIndex = piecesInPlay.findIndex(piece => {
+      const pieceNumberMatch = piece.id.match(/^[ib]-(\d+)$/);
+      return pieceNumberMatch && pieceNumberMatch[1] === pieceNumber;
+    });
+    
+    if (pieceIndex === -1) {
+      console.error('Piece not found');
+      console.log(`Could not find ${pieceId}`)
+      console.log(piecesInPlay);
+      return;
+    }
+    const updatedPieces = [...piecesInPlay];
+    updatedPieces[pieceIndex].isStable = isStable;
+    setPiecesInPlay(updatedPieces);
+  }
   return (
     <PiecesInPlayContext.Provider
       value={{
@@ -151,6 +187,7 @@ export function PiecesInPlayProvider({
         updateDimensions,
         resetPieces,
         setPiecesForNewLevel,
+        setPieceStability,
       }}
     >
       {children}

--- a/src/context/PiecesInPlay.tsx
+++ b/src/context/PiecesInPlay.tsx
@@ -49,7 +49,8 @@ export function PiecesInPlayProvider({
   );
   const { boardWidth, boardHeight } = boardDimensions;
 
-  function movePiece(pieceIndex: number, newLocation: string | null) {
+  function movePiece(pieceId, newLocation: string | null) {
+    const pieceIndex = piecesInPlay.findIndex(piece => piece.id === pieceId);
     const updatedPieces = [...piecesInPlay];
     const oldLocation = piecesInPlay[pieceIndex].location;
     const { x: oldX, y: oldY } = convertLocationToXAndY(oldLocation);
@@ -90,7 +91,12 @@ export function PiecesInPlayProvider({
     }
   }
 
-  function updateDimensions(pieceIndex: number, width: number, height: number) {
+  function updateDimensions(pieceId: number, width: number, height: number) {
+    const pieceIndex = piecesInPlay.findIndex(piece => piece.id === pieceId);
+    if (pieceIndex === -1) {
+      console.error('Piece not found');
+      return;
+    }
     const updatedPieces = [...piecesInPlay];
     const {
       location,

--- a/src/context/PiecesInPlay.tsx
+++ b/src/context/PiecesInPlay.tsx
@@ -64,18 +64,21 @@ export function PiecesInPlayProvider({
       setPiecesInPlay(updatedPieces);
       if (outerOverlaps + innerOverlaps > 0) {
         updatedPieces[pieceIndex].isStable = false;
+        setPieceStability(`b-${pieceIndex}`, false);
         setPiecesInPlay(updatedPieces);
         Hotjar.event('piece placed partially overlapping another piece');
       } else if (squaresOutsideBoard > 0) {
-        updatedPieces[pieceIndex].isStable = false;
+        setPieceStability(`b-${pieceIndex}`, false);
         setPiecesInPlay(updatedPieces);
         Hotjar.event('piece placed partially off board');
       } else {
         updatedPieces[pieceIndex].isStable = true;
+        setPieceStability(`b-${pieceIndex}`, true);
       }
     } else if (newLocation === null) {
       updatedPieces[pieceIndex].location = null;
       updatedPieces[pieceIndex].id = `i-${pieceIndex}`;
+      setPieceStability(`i-${pieceIndex}`, true);
       setPiecesInPlay(updatedPieces);
       if (oldLocation !== null) {
         Hotjar.event('move off of board');
@@ -93,9 +96,9 @@ export function PiecesInPlayProvider({
     updatedPieces[pieceIndex].width = newWidth;
     updatedPieces[pieceIndex].height = newHeight;
     if (newWidth > boardWidth || newHeight > boardHeight) {
-      updatedPieces[pieceIndex].isStable = false;
+      setPieceStability(`b-${pieceIndex}`, false);
     } else {
-      updatedPieces[pieceIndex].isStable = true;
+      setPieceStability(`b-${pieceIndex}`, true);
     }
     setPiecesInPlay(updatedPieces);
   }

--- a/src/hooks/useClickAway.ts
+++ b/src/hooks/useClickAway.ts
@@ -1,15 +1,15 @@
 // Not currently in use YET
 
-import { useEffect } from 'react';
-function useClickAway(callback: () => void) {
-  useEffect(() => {
-    function handleClickAway(event: MouseEvent) {
-      console.log(event);
-    }
-    window.addEventListener('click', handleClickAway);
-    return () => {
-      window.removeEventListener('click', handleClickAway);
-    };
-  }, [callback]);
-}
-export default useClickAway;
+// import { useEffect } from 'react';
+// function useClickAway(callback: () => void) {
+//   useEffect(() => {
+//     function handleClickAway(event: MouseEvent) {
+//       console.log(event);
+//     }
+//     window.addEventListener('click', handleClickAway);
+//     return () => {
+//       window.removeEventListener('click', handleClickAway);
+//     };
+//   }, [callback]);
+// }
+// export default useClickAway;

--- a/src/hooks/useItemPosition.ts
+++ b/src/hooks/useItemPosition.ts
@@ -1,25 +1,25 @@
 // Not currently in use
 
-import { useState, useEffect } from 'react';
+// import { useState, useEffect } from 'react';
 
-export function useElementPosition(elementRef: React.RefObject<HTMLElement>) {
-  const [position, setPosition] = useState({ x: 0, y: 0 });
+// export function useElementPosition(elementRef: React.RefObject<HTMLElement>) {
+//   const [position, setPosition] = useState({ x: 0, y: 0 });
 
-  useEffect(() => {
-    const updatePosition = () => {
-      if (elementRef.current) {
-        const rect = elementRef.current.getBoundingClientRect();
-        setPosition({ x: rect.left, y: rect.top });
-      }
-    };
+//   useEffect(() => {
+//     const updatePosition = () => {
+//       if (elementRef.current) {
+//         const rect = elementRef.current.getBoundingClientRect();
+//         setPosition({ x: rect.left, y: rect.top });
+//       }
+//     };
 
-    // sets the initial position
-    updatePosition();
+//     // sets the initial position
+//     updatePosition();
 
-    window.addEventListener('resize', updatePosition);
+//     window.addEventListener('resize', updatePosition);
 
-    return () => window.removeEventListener('resize', updatePosition);
-  }, [elementRef]);
+//     return () => window.removeEventListener('resize', updatePosition);
+//   }, [elementRef]);
 
-  return position;
+//   return position;
 }

--- a/src/hooks/useSnapToGrid.ts
+++ b/src/hooks/useSnapToGrid.ts
@@ -1,43 +1,44 @@
-// Not currently in use
+// Not currently in use but I may use it for ghosting to show where the piece will  be dropped on the board.
+
 // import { Modifier } from '@dnd-kit/core';
 // import { useMemo } from 'react';
 
-export function useSnapToGrid(
-  gridSize: number,
-  origin: { x: number; y: number }
-) {
-  // return useMemo(() => {
-  return ({ transform }: { transform: { x: number; y: number } }) => {
-    let xOffset = (transform.x - origin.x) % gridSize;
+// export function useSnapToGrid(
+//   gridSize: number,
+//   origin: { x: number; y: number }
+// ) {
+//   // return useMemo(() => {
+//   return ({ transform }: { transform: { x: number; y: number } }) => {
+//     let xOffset = (transform.x - origin.x) % gridSize;
 
-    if (xOffset > gridSize / 2) {
-      xOffset -= gridSize;
-    }
-    // if (xOffset < 0) {
-    //   xOffset += gridSize;
-    // }
+//     if (xOffset > gridSize / 2) {
+//       xOffset -= gridSize;
+//     }
+//     // if (xOffset < 0) {
+//     //   xOffset += gridSize;
+//     // }
 
-    let yOffset = (transform.y - origin.y) % gridSize;
+//     let yOffset = (transform.y - origin.y) % gridSize;
 
-    // if (yOffset < 0) {
-    //   yOffset += gridSize;
-    // }
+//     // if (yOffset < 0) {
+//     //   yOffset += gridSize;
+//     // }
 
-    console.log('origin', origin);
-    console.log('xOffset', xOffset);
-    console.log('yOffset', yOffset);
-    console.log('transform', transform);
-    console.log('gridSize', gridSize);
-    // let xOffset = 0;
-    // let yOffset = 0;
+//     console.log('origin', origin);
+//     console.log('xOffset', xOffset);
+//     console.log('yOffset', yOffset);
+//     console.log('transform', transform);
+//     console.log('gridSize', gridSize);
+//     // let xOffset = 0;
+//     // let yOffset = 0;
 
-    return {
-      ...transform,
-      x: Math.ceil(transform.x / gridSize) * gridSize + xOffset,
-      y: Math.ceil(transform.y / gridSize) * gridSize + yOffset,
-    };
-  };
-  // }, [gridSize, origin]);
-}
+//     return {
+//       ...transform,
+//       x: Math.ceil(transform.x / gridSize) * gridSize + xOffset,
+//       y: Math.ceil(transform.y / gridSize) * gridSize + yOffset,
+//     };
+//   };
+//   // }, [gridSize, origin]);
+// }
 
-export default useSnapToGrid;
+// export default useSnapToGrid;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,19 +7,22 @@ import { SelectedPieceProvider } from './context/SelectedPiece';
 import { CurrentLevelProvider } from './context/CurrentLevel';
 import { BoardSquaresProvider } from './context/BoardSquares';
 import { LevelProgressProvider } from './context/LevelProgress';
+import ErrorBoundary from './components/ErrorBoundary';
 
 createRoot(document.getElementById('root') as HTMLElement).render(
-  //<StrictMode>
-  <CurrentLevelProvider>
-    <LevelProgressProvider>
-      <BoardSquaresProvider>
-        <PiecesInPlayProvider>
-          <SelectedPieceProvider>
-            <App />
-          </SelectedPieceProvider>
-        </PiecesInPlayProvider>
-      </BoardSquaresProvider>
-    </LevelProgressProvider>
-  </CurrentLevelProvider>
-  // </StrictMode>
+  <StrictMode>
+    <ErrorBoundary>
+      <CurrentLevelProvider>
+        <LevelProgressProvider>
+          <BoardSquaresProvider>
+            <PiecesInPlayProvider>
+              <SelectedPieceProvider>
+                <App />
+              </SelectedPieceProvider>
+            </PiecesInPlayProvider>
+          </BoardSquaresProvider>
+        </LevelProgressProvider>
+      </CurrentLevelProvider>
+    </ErrorBoundary>
+  </StrictMode>
 );

--- a/src/pages/game.tsx
+++ b/src/pages/game.tsx
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { useContext, useState } from 'react';
+import { useContext, useState} from 'react';
 import levels from '../Game/levels.json' with { type: 'json' };
 import InitialPuzzlePiece from '../Game/PuzzlePieces/InitialPuzzlePiece';
 import PieceOverlay from '../Game/PuzzlePieces/PieceOverlay';
@@ -184,15 +184,12 @@ export const PiecesContainer = styled(motion.div).attrs({
   flex-direction: row;
   flex-wrap: wrap;
   align-items: start;
-  justify-content: space-between; 
   gap: calc(var(--sizeOfEachUnit) / 2);
   overflow-y: auto;
   max-height:  65vh;
   height: fit-content;
   padding-top: 10px;
   line-height: 0;
-  background-color: hsl(100, 65%, 89%);
-  border: 8px solid hsl(178, 100%, 23%);
   margin-inline: 10px;
   padding: 18px;
 

--- a/src/pages/game.tsx
+++ b/src/pages/game.tsx
@@ -1,6 +1,5 @@
 // @ts-nocheck
-<<<<<<< Updated upstream
-import { useContext, useState, useRef } from 'react';
+import { useContext, useState } from 'react';
 import levels from '../Game/levels.json' with { type: 'json' };
 import InitialPuzzlePiece from '../Game/PuzzlePieces/InitialPuzzlePiece';
 import PieceOverlay from '../Game/PuzzlePieces/PieceOverlay';
@@ -39,7 +38,6 @@ function Game() {
     useContext(PiecesInPlayContext);
   const [isRotating, setIsRotating] = useState(false);
   const [levelCompletedShown, setLevelCompletedShown] = useState(false);
- // const boardRef = useRef(null);
 
   const handleCloseModal = () => {
     setLevelCompletedShown(true); // Prevent modal from showing again for this level
@@ -88,7 +86,7 @@ function Game() {
                 isActive={activePiece?.id === piece.id}
                 isRotating={isRotating}
                 setIsRotating={setIsRotating}
-                key={pieceIndex}
+                key={piece.id}
                 setActivePiece={setActivePiece}
               />
             );

--- a/src/pages/game.tsx
+++ b/src/pages/game.tsx
@@ -78,7 +78,6 @@ function Game() {
 
   return (
     <>
-      <ErrorBoundary>
       <Main id='main'>
         <ErrorBoundary>
       <DragAndDropArea data-testid='drag-and-drop-area'
@@ -87,8 +86,8 @@ function Game() {
         isRotating={isRotating}
         setIsRotating={setIsRotating}
           >
-        <PiecesContainer data-testid='pieces-container' $currentLevel={currentLevel}>
-          {piecesInPlay.map((piece: Piece, pieceIndex: number) => {
+        <PiecesContainer data-testid='pieces-container' $currentLevel={currentLevel} key={currentLevel}>  
+          {piecesInPlay.map((piece: Piece) => {
             if (piece.location != null) return null;
             return (
               <InitialPuzzlePiece
@@ -144,8 +143,7 @@ function Game() {
         levelCompletedShown={levelCompletedShown}
         onClose={handleCloseModal}
         />
-        </ErrorBoundary>
-    </>
+        </>
   );
 }
 
@@ -189,7 +187,6 @@ export const BoardWrapper = styled.div`
 
 export const PiecesContainer = styled(motion.div).attrs({
   layout: true,
-  key: props => props.$currentLevel,
 })<{ $currentLevel: number }>`
   display: flex;
   flex-direction: row;

--- a/src/pages/game.tsx
+++ b/src/pages/game.tsx
@@ -69,6 +69,7 @@ function Game() {
 
   return (
     <>
+      <ErrorBoundary>
       <Main id='main'>
         <ErrorBoundary>
       <DragAndDropArea id='drag-and-drop-area'
@@ -133,7 +134,8 @@ function Game() {
         completed={checkIfPassedLevel()} 
         levelCompletedShown={levelCompletedShown}
         onClose={handleCloseModal}
-      />
+        />
+        </ErrorBoundary>
     </>
   );
 }

--- a/src/pages/game.tsx
+++ b/src/pages/game.tsx
@@ -1,22 +1,21 @@
-// @ts-nocheck
 import { useContext, useState} from 'react';
 import levels from '../Game/levels.json' with { type: 'json' };
 import InitialPuzzlePiece from '../Game/PuzzlePieces/InitialPuzzlePiece';
 import PieceOverlay from '../Game/PuzzlePieces/PieceOverlay';
 import Board from '../Game/Board/Board';
-import PlacedPieces from '../Game/PlacedPieces.tsx';
+import PlacedPieces from '../Game/PlacedPieces';
 import DragAndDropArea from '../Game/DragAndDropArea';
-import Button from '../components/Button.tsx';
+import Button from '../components/Button';
 import InstructionsModal from '../Game/Instructions/InstructionsModal';
 import LevelCompleteModal from '../Game/LevelComplete';
 import { motion } from 'motion/react';
 import styled from 'styled-components';
 import { DragOverlay } from '@dnd-kit/core';
 import { PiecesInPlayContext } from '../context/PiecesInPlay';
-import { CurrentLevelContext } from '../context/CurrentLevel.tsx';
+import { CurrentLevelContext } from '../context/CurrentLevel';
 import { getInitialPieces } from '../Game/utils/getInitialPieces';
-import { LevelProgressContext } from '../context/LevelProgress.tsx';
-import { Piece } from '../types/piece.ts';
+import { LevelProgressContext } from '../context/LevelProgress';
+import { Piece } from '../types/piece';
 import { BoardSquaresContext } from '../context/BoardSquares';
 import Hotjar from '@hotjar/browser';
 import { ChevronLeft, ChevronRight, RotateCcw, HelpCircle } from 'lucide-react';
@@ -29,13 +28,23 @@ function Game() {
     levelPosition,
     previousLevel,
     nextLevel,
-    setSizeOfEachUnit,
   } = useContext(CurrentLevelContext);
   const [activePiece, setActivePiece] = useState<Piece | null>(null);
-  const { isLevelCompleted } = useContext(LevelProgressContext);
-  const { boardSquares, resetBoardSquares, checkIfPassedLevel } = useContext(BoardSquaresContext);
-    const { piecesInPlay, resetPieces, setPiecesForNewLevel } =
-    useContext(PiecesInPlayContext);
+  const levelProgressContext = useContext(LevelProgressContext);
+  if (!levelProgressContext) {
+    throw new Error('LevelProgressContext must be used within a LevelProgressProvider');
+  }
+  const { isLevelCompleted } = levelProgressContext;
+  const boardSquaresContext = useContext(BoardSquaresContext);
+  if (!boardSquaresContext) {
+    throw new Error('BoardSquaresContext must be used within a BoardSquaresProvider');
+  }
+  const { resetBoardSquares, checkIfPassedLevel } = boardSquaresContext;
+  const piecesInPlayContext = useContext(PiecesInPlayContext);
+  if (!piecesInPlayContext) {
+    throw new Error('PiecesInPlayContext must be used within a PiecesInPlayProvider');
+  }
+  const { piecesInPlay, resetPieces, setPiecesForNewLevel } = piecesInPlayContext;
   const [isRotating, setIsRotating] = useState(false);
   const [levelCompletedShown, setLevelCompletedShown] = useState(false);
 
@@ -47,7 +56,7 @@ function Game() {
     await previousLevel();
     const newPieces = getInitialPieces(currentLevel - 1);
     await setPiecesForNewLevel(newPieces);
-    await setSizeOfEachUnit(currentLevel - 1);
+    //await setSizeOfEachUnit(currentLevel - 1);
     await resetBoardSquares(currentLevel - 1);
     setLevelCompletedShown(false); // Reset modal state for new level
   }
@@ -56,7 +65,7 @@ function Game() {
     await nextLevel();
     const newPieces = getInitialPieces(currentLevel + 1);
     await setPiecesForNewLevel(newPieces);
-    await setSizeOfEachUnit(currentLevel + 1);
+    //await setSizeOfEachUnit(currentLevel + 1);
     await resetBoardSquares(currentLevel + 1);
     setLevelCompletedShown(false); // Reset modal state for new level
   }
@@ -72,13 +81,13 @@ function Game() {
       <ErrorBoundary>
       <Main id='main'>
         <ErrorBoundary>
-      <DragAndDropArea id='drag-and-drop-area'
+      <DragAndDropArea data-testid='drag-and-drop-area'
         setActivePiece={setActivePiece}
         key={currentLevel}
         isRotating={isRotating}
         setIsRotating={setIsRotating}
           >
-        <PiecesContainer id='pieces-container' $currentLevel={currentLevel}>
+        <PiecesContainer data-testid='pieces-container' $currentLevel={currentLevel}>
           {piecesInPlay.map((piece: Piece, pieceIndex: number) => {
             if (piece.location != null) return null;
             return (
@@ -93,7 +102,7 @@ function Game() {
             );
           })}
               </PiecesContainer>
-        <BoardWrapper id='board-wrapper'>
+        <BoardWrapper data-testid='board-wrapper'>
           <Board
             dimensions={levels[currentLevel].dimensions}
             boardSections={levels[currentLevel].boardSections}
@@ -112,10 +121,10 @@ function Game() {
           </DragAndDropArea>
               </ErrorBoundary>
        </Main>
-      <ButtonContainer id='button-container'>
+      <ButtonContainer data-testid='button-container'>
         <Button color='hsl(178, 30.00%, 56.10%)' textColor='black' disabled={levelPosition == 'first'} onClick={setToPrevious}>
-        <ChevronLeft />Previous Level 
-        </Button>
+        <ChevronLeft />Previous Level
+          </Button>
         <Button color='hsl(178, 100%, 23%)' textColor='white' disabled={levelPosition == 'last'} onClick={setToNext}>
         Next Level <ChevronRight />
         </Button>

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,8 +1,73 @@
-// @ts-nocheck
-
 import styled from 'styled-components';
 import { useNavigate } from 'react-router';
 import MathematicalToolsGrid from '../components/MathematicalToolsGrid';
+
+function Home() {
+  const navigate = useNavigate();
+
+  const handlePlayGame = () => {
+    navigate('/game');
+  };
+
+  return (
+    <div>
+      <HeroSection>
+        <Container>
+          <Title>Frectangles</Title>
+          <Subtitle>Where Math Meets Puzzle-Solving Fun</Subtitle>
+          <PlayButton onClick={handlePlayGame}>Play Game</PlayButton>
+        </Container>
+      </HeroSection>
+
+      <Container>
+        <Section>
+          <SectionTitle>Perfect for Students & Teachers</SectionTitle>
+          <BenefitsGrid>
+            <BenefitCard>
+              <BenefitTitle>Build Number Intuition</BenefitTitle>
+              <BenefitText>
+                Students practice estimating the magnitude of numbers while
+                manipulating puzzle pieces, developing a deeper understanding of
+                numerical relationships.
+              </BenefitText>
+            </BenefitCard>
+            <BenefitCard>
+              <BenefitTitle>Visualize Math Properties</BenefitTitle>
+              <BenefitText>
+                Make abstract mathematical concepts concrete through hands-on
+                manipulation of shapes and sizes, connecting operations to
+                visual representations.
+              </BenefitText>
+            </BenefitCard>
+            <BenefitCard>
+              <BenefitTitle>Classroom Ready</BenefitTitle>
+              <BenefitText>
+                Teachers can use these informal experiences as launching points
+                for deeper discussions about mathematical expressions and
+                equivalent operations.
+              </BenefitText>
+            </BenefitCard>
+          </BenefitsGrid>
+        </Section>
+      </Container>
+
+      <MathematicalToolsGrid />
+
+      <CallToAction>
+        <Container>
+          <CTATitle>Ready to Transform Math Learning?</CTATitle>
+          <CTAText>
+            Start building mathematical intuition through interactive puzzle
+            solving
+          </CTAText>
+          <PlayButton onClick={handlePlayGame}>Start Playing Now</PlayButton>
+        </Container>
+      </CallToAction>
+    </div>
+  );
+}
+
+export default Home;
 
 const Container = styled.div`
   max-width: 1200px;
@@ -142,70 +207,3 @@ const CTAText = styled.p`
   margin-bottom: 2rem;
   opacity: 0.9;
 `;
-
-function Home() {
-  const navigate = useNavigate();
-
-  const handlePlayGame = () => {
-    navigate('/game');
-  };
-
-  return (
-    <div>
-      <HeroSection>
-        <Container>
-          <Title>Frectangles</Title>
-          <Subtitle>Where Math Meets Puzzle-Solving Fun</Subtitle>
-          <PlayButton onClick={handlePlayGame}>Play Game</PlayButton>
-        </Container>
-      </HeroSection>
-
-      <Container>
-        <Section>
-          <SectionTitle>Perfect for Students & Teachers</SectionTitle>
-          <BenefitsGrid>
-            <BenefitCard>
-              <BenefitTitle>Build Number Intuition</BenefitTitle>
-              <BenefitText>
-                Students practice estimating the magnitude of numbers while
-                manipulating puzzle pieces, developing a deeper understanding of
-                numerical relationships.
-              </BenefitText>
-            </BenefitCard>
-            <BenefitCard>
-              <BenefitTitle>Visualize Math Properties</BenefitTitle>
-              <BenefitText>
-                Make abstract mathematical concepts concrete through hands-on
-                manipulation of shapes and sizes, connecting operations to
-                visual representations.
-              </BenefitText>
-            </BenefitCard>
-            <BenefitCard>
-              <BenefitTitle>Classroom Ready</BenefitTitle>
-              <BenefitText>
-                Teachers can use these informal experiences as launching points
-                for deeper discussions about mathematical expressions and
-                equivalent operations.
-              </BenefitText>
-            </BenefitCard>
-          </BenefitsGrid>
-        </Section>
-      </Container>
-
-      <MathematicalToolsGrid />
-
-      <CallToAction>
-        <Container>
-          <CTATitle>Ready to Transform Math Learning?</CTATitle>
-          <CTAText>
-            Start building mathematical intuition through interactive puzzle
-            solving
-          </CTAText>
-          <PlayButton onClick={handlePlayGame}>Start Playing Now</PlayButton>
-        </Container>
-      </CallToAction>
-    </div>
-  );
-}
-
-export default Home;

--- a/src/types/piece.ts
+++ b/src/types/piece.ts
@@ -1,11 +1,11 @@
 export interface Piece {
   width: number;
   height: number;
-  id?: string;
+  id: string;
   location: string | null;
-  isRotated?: boolean;
-  color?: string;
-  isStable?: boolean;
+  isRotated: boolean;
+  color: string;
+  isStable: boolean;
 }
 
 export interface InitialPiece {


### PR DESCRIPTION
Addressed TypeScript errors by defining types more accurately and early returning to avoid the need for optional chaining everywhere. I also decoupled the pieceIndex from the functions that apply actions to the pieces so the indexes can change and not break everything. 

Closes #106 
Closes #72 
Closes #44 
Closes #41 